### PR TITLE
MOM6: +Removed hard newlines in get_param calls

### DIFF
--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,65 +416,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "Vertical_coordinate.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -520,41 +473,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -570,285 +520,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = True     !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = False    !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = False !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -856,50 +763,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -909,190 +810,160 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1102,53 +973,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1158,559 +1020,490 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1727,93 +1520,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 1000000              !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "B"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1825,90 +1609,78 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "B"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
@@ -5,60 +5,49 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -74,8 +63,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -112,14 +101,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -175,26 +164,21 @@ COORD_FILE = "Vertical_coordinate.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
@@ -202,66 +186,58 @@ ADJUST_THICKNESS = True         !   [Boolean] default = False
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -271,34 +247,30 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = True     !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 CONT_PPM_BETTER_ITER = False    !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = False !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -309,58 +281,47 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -370,28 +331,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -403,97 +360,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -506,51 +454,45 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -564,63 +506,54 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 1000000              !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 OCEAN_SURFACE_STAGGER = "B"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 WIND_STAGGER = "B"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,65 +416,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -520,41 +473,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -570,285 +520,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -856,50 +763,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -909,186 +810,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1098,53 +969,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1154,563 +1016,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1727,93 +1519,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1825,90 +1608,78 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -82,8 +70,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -120,14 +108,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -183,26 +171,21 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
@@ -210,92 +193,81 @@ ADJUST_THICKNESS = True         !   [Boolean] default = False
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -306,57 +278,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -366,28 +327,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -399,97 +356,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -502,55 +450,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -564,54 +505,47 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -490,12 +488,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 6                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 5                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 6, 5                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
@@ -11,16 +11,14 @@ DT_RADIATION = 1.08E+04         !   [s] default = 7200.0
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -31,8 +29,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -132,6 +130,5 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,65 +416,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -520,41 +473,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -570,285 +520,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -856,50 +763,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -909,186 +810,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1098,53 +969,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1154,563 +1016,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1727,93 +1519,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1825,90 +1608,78 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -82,8 +70,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -120,14 +108,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -183,26 +171,21 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
@@ -210,92 +193,81 @@ ADJUST_THICKNESS = True         !   [Boolean] default = False
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -306,57 +278,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -366,28 +327,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -399,97 +356,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -502,55 +450,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -564,54 +505,47 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -487,12 +485,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
@@ -11,16 +11,14 @@ DT_RADIATION = 1.08E+04         !   [s] default = 7200.0
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -31,8 +29,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -132,6 +130,5 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,65 +416,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -520,41 +473,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -570,285 +520,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -856,50 +763,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -909,178 +810,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
+RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
+                                ! If true, the viscosity contribution from MEKE is scaled by the resolution
+                                ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
+AH_TIME_SCALE = 0.0             !   [s] default = 0.0
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1090,53 +969,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1146,563 +1016,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1719,93 +1519,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1817,90 +1608,78 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
@@ -5,72 +5,59 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -86,8 +73,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -124,14 +111,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -187,26 +174,21 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
@@ -214,92 +196,81 @@ ADJUST_THICKNESS = True         !   [Boolean] default = False
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -310,57 +281,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -370,28 +330,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -403,97 +359,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -506,55 +453,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -568,54 +508,47 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -492,12 +490,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_parameter_doc.short
@@ -11,16 +11,14 @@ DT_RADIATION = 1.08E+04         !   [s] default = 7200.0
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -31,8 +29,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -141,6 +139,5 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 14                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,65 +416,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -520,41 +473,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -570,285 +520,242 @@ DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -856,50 +763,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -909,186 +810,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1098,53 +969,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1154,563 +1016,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1727,93 +1519,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1825,118 +1608,103 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 999.0      !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -5,65 +5,53 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -79,8 +67,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -117,14 +105,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -180,31 +168,25 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -222,92 +204,81 @@ DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -318,57 +289,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -378,28 +338,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -411,97 +367,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -514,55 +461,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -576,65 +516,56 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 608.4598627866924 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -508,12 +506,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.layout
@@ -4,97 +4,90 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 NIHALO_FAST = 0                 ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO_FAST = 0                 ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE_FAST = "MOM_mask_table" ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC_FAST = 2                 !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC_FAST = 1                 !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT_FAST = 2, 1              !
                                 ! The processor layout that was actually used.
 IO_LAYOUT_FAST = 1, 1           ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
@@ -21,13 +21,11 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -38,8 +36,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -142,6 +140,5 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 20.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 45.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 45.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -2.1          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 14                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 50                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -294,54 +266,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -361,8 +328,8 @@ USE_ADVECTION_TEST_TRACER = True !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -372,27 +339,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module advection_test_tracer ===
 ADVECTION_TEST_X_ORIGIN = 19.5  !   [not defined] default = 0.0
@@ -404,13 +369,11 @@ ADVECTION_TEST_X_WIDTH = 1.0    !   [not defined] default = 0.0
 ADVECTION_TEST_Y_WIDTH = 1.0    !   [not defined] default = 0.0
                                 ! The y-width of the test-functions.
 ADVECTION_TEST_TRACER_IC_FILE = "" ! default = ""
-                                ! The name of a file from which to read the initial
-                                ! conditions for the tracers, or blank to initialize
-                                ! them internally.
+                                ! The name of a file from which to read the initial conditions for the tracers,
+                                ! or blank to initialize them internally.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified from MOM_initialization.F90.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified from MOM_initialization.F90.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -436,16 +399,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -456,8 +417,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -477,46 +437,40 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -527,48 +481,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -578,17 +524,16 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
@@ -596,23 +541,22 @@ REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -628,53 +572,49 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 0.0                !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -682,314 +622,273 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -997,107 +896,98 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the S2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the S2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_N2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the N2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the N2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_O1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the O1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the O1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_P1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the P1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the P1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_Q1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the Q1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the Q1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MF = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MF
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MF frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MM = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MM
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MM frequency. This is only used
+                                ! if TIDES is true.
 TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
-                                ! If true, read the tidal self-attraction and loading
-                                ! from input files, specified by TIDAL_INPUT_FILE.
-                                ! This is only used if TIDES is true.
+                                ! If true, read the tidal self-attraction and loading from input files,
+                                ! specified by TIDAL_INPUT_FILE. This is only used if TIDES is true.
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
-                                ! If true, use the SAL from the previous iteration of the
-                                ! tides to facilitate convergent iteration.
-                                ! This is only used if TIDES is true.
+                                ! If true, use the SAL from the previous iteration of the tides to facilitate
+                                ! convergent iteration. This is only used if TIDES is true.
 TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
-                                ! If true and TIDES is true, use the scalar approximation
-                                ! when calculating self-attraction and loading.
+                                ! If true and TIDES is true, use the scalar approximation when calculating
+                                ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 TIDE_M2_FREQ = 1.405189E-04     !   [s-1] default = 1.405189E-04
-                                ! Frequency of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Frequency of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_AMP = 0.242334          !   [m] default = 0.242334
-                                ! Amplitude of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Amplitude of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_PHASE_T0 = 0.0          !   [radians] default = 0.0
-                                ! Phase of the M2 tidal constituent at time 0.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Phase of the M2 tidal constituent at time 0. This is only used if TIDES and
+                                ! TIDE_M2 are true.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1107,194 +997,162 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1304,53 +1162,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -1360,455 +1209,402 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 0.0          !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 0.0        !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_DENSITY_DIFF = 0.03         !   [kg/m3] default = 0.03
-                                ! Density difference used to detect the mixed-layer
-                                ! depth used for the mixed-layer eddy parameterization
-                                ! by Fox-Kemper et al. (2010)
+                                ! Density difference used to detect the mixed-layer depth used for the
+                                ! mixed-layer eddy parameterization by Fox-Kemper et al. (2010)
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1817,150 +1613,134 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -1977,99 +1757,89 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2081,90 +1851,78 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = -1.0               !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 1.0E-04              !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -5,70 +5,58 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -84,8 +72,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -122,14 +110,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -188,9 +176,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -199,8 +186,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -220,10 +206,9 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -235,22 +220,18 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
@@ -258,74 +239,63 @@ Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 
@@ -333,105 +303,88 @@ TIDES = True                    !   [Boolean] default = False
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -441,35 +394,30 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -478,87 +426,79 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -571,23 +511,21 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -613,29 +551,25 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 
 ! === module MOM_surface_forcing ===
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 608.4598627866924 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -490,12 +488,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
@@ -12,13 +12,11 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 23                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 14                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -29,8 +27,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -112,6 +110,5 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 3600.0      !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 97                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 105                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 105                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,8 +260,8 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
-                                ! If true, the channel configuration list works for any
-                                ! longitudes in the range of -360 to 360.
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -299,54 +271,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -366,8 +333,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -377,27 +344,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -423,16 +388,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -443,12 +406,10 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -459,14 +420,11 @@ INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -488,12 +446,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -517,43 +473,38 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -564,48 +515,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -615,45 +558,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -667,8 +607,7 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
                                 !                by a comma or space, for sigma-2 and dz. e.g.
                                 !                HYBRID:vgrid.nc,sigma2,dz
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -684,53 +623,49 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -738,317 +673,279 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
+MEKE_MIN_LSCALE = False         !   [Boolean] default = False
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -1056,50 +953,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1109,198 +1000,172 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
+RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
+                                ! If true, the viscosity contribution from MEKE is scaled by the resolution
+                                ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
+AH_TIME_SCALE = 0.0             !   [s] default = 0.0
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 ICE_LENGTH_DYN_PSURF = 1.0E+04  !   [m] default = 1.0E+04
-                                ! The length scale at which the Rayleigh damping rate due
-                                ! to the ice strength should be the same as if a Laplacian
-                                ! were applied, if DYNAMIC_SURFACE_PRESSURE is true.
+                                ! The length scale at which the Rayleigh damping rate due to the ice strength
+                                ! should be the same as if a Laplacian were applied, if DYNAMIC_SURFACE_PRESSURE
+                                ! is true.
 DEPTH_MIN_DYN_PSURF = 1.0E-06   !   [m] default = 1.0E-06
-                                ! The minimum depth to use in limiting the size of the
-                                ! dynamic surface pressure for stability, if
-                                ! DYNAMIC_SURFACE_PRESSURE is true..
+                                ! The minimum depth to use in limiting the size of the dynamic surface pressure
+                                ! for stability, if DYNAMIC_SURFACE_PRESSURE is true..
 CONST_DYN_PSURF = 0.9           !   [nondim] default = 0.9
-                                ! The constant that scales the dynamic surface pressure,
-                                ! if DYNAMIC_SURFACE_PRESSURE is true.  Stable values
-                                ! are < ~1.0.
+                                ! The constant that scales the dynamic surface pressure, if
+                                ! DYNAMIC_SURFACE_PRESSURE is true.  Stable values are < ~1.0.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1310,53 +1175,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1366,473 +1222,418 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 500.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.5E-06             !   [m2 s-1] default = 1.5E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
-                                ! When the Polzin decay profile is used, this is a
-                                ! non-dimensional constant in the expression for the
-                                ! vertical scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
-                                ! When the Polzin decay profile is used, this is the
-                                ! reference value of the buoyancy frequency at the ocean
-                                ! bottom in the Polzin formulation for the vertical
-                                ! scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a
-                                ! scale factor for the vertical scale of decay of the tidal
-                                ! energy dissipation.
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
 POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a factor
-                                ! to limit the vertical scale of decay of the tidal
-                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
-                                ! times the depth of the ocean.
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
 POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
-                                ! When the Polzin decay profile is used, this is the
-                                ! minimum vertical decay scale for the vertical profile
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
                                 ! of internal tide dissipation with the Polzin (2009) formulation
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v20140616.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.161895003862225E-05 !   [m] default = 1.161895003862225E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.5E-05                  !   [m2 s-1] default = 1.5E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.5E-05      !   [m2 s-1] default = 1.5E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -1841,101 +1642,91 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -1948,67 +1739,61 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching stable
+                                ! Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.v20140616.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -2025,89 +1810,81 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2119,124 +1896,110 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.v20140616.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_MEAN_DENSITY = 900.0    !   [kg m-3] default = 900.0
-                                ! A typical density of sea ice, used with the kinematic
-                                ! viscosity, when USE_RIGID_SEA_ICE is true.
+                                ! A typical density of sea ice, used with the kinematic viscosity, when
+                                ! USE_RIGID_SEA_ICE is true.
 SEA_ICE_VISCOSITY = 1.0E+09     !   [m2 s-1] default = 1.0E+09
-                                ! The kinematic viscosity of sufficiently thick sea ice
-                                ! for use in calculating the rigidity of sea ice.
+                                ! The kinematic viscosity of sufficiently thick sea ice for use in calculating
+                                ! the rigidity of sea ice.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 4                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 4                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 4, 4                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
@@ -5,84 +5,72 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 97                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 105                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -98,8 +86,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -138,17 +126,17 @@ TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -167,14 +155,13 @@ CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
 
 ! === module MOM_EOS ===
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
@@ -204,9 +191,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -215,14 +201,11 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -244,9 +227,8 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -270,10 +252,9 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -285,36 +266,31 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -330,90 +306,78 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -423,23 +387,21 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -447,140 +409,117 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 MLE_FRONT_LENGTH = 500.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -589,37 +528,35 @@ EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v20140616.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -628,56 +565,49 @@ H2_FILE = "ocean_topog.nc"      !
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -688,9 +618,9 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -699,50 +629,46 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -755,29 +681,27 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.v20140616.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -790,50 +714,45 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
 
 ! === module MOM_tracer_hor_diff ===
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.v20140616.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
@@ -841,11 +760,11 @@ CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 97                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 105                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 621.958251953125 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -490,12 +488,10 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 4                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 4                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 4, 4                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.short
@@ -16,13 +16,11 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 97                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 105                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -33,8 +31,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -144,6 +142,5 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1.08E+04             !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 1.08E+04    !   [s] default = 1.08E+04
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 49                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 53                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 53                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,8 +260,8 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
-                                ! If true, the channel configuration list works for any
-                                ! longitudes in the range of -360 to 360.
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -299,54 +271,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -366,8 +333,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -377,27 +344,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -423,16 +388,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -443,12 +406,10 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -459,14 +420,11 @@ INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -488,12 +446,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -517,43 +473,38 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -564,48 +515,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = True !   [Boolean] default = True
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -615,45 +558,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -667,8 +607,7 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
                                 !                by a comma or space, for sigma-2 and dz. e.g.
                                 !                HYBRID:vgrid.nc,sigma2,dz
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -684,53 +623,49 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -738,320 +673,282 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
+MEKE_MIN_LSCALE = False         !   [Boolean] default = False
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 RESOLN_N2_FILTER_DEPTH = 2000.0 !   [m] default = 2000.0
-                                ! The depth below which N2 is monotonized to avoid stratification
-                                ! artifacts from altering the equivalent barotropic mode structure.
+                                ! The depth below which N2 is monotonized to avoid stratification artifacts from
+                                ! altering the equivalent barotropic mode structure.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 100         !   [nondim] default = 100
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -1059,50 +956,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1112,198 +1003,172 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
+RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
+                                ! If true, the viscosity contribution from MEKE is scaled by the resolution
+                                ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
+AH_TIME_SCALE = 0.0             !   [s] default = 0.0
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 ICE_LENGTH_DYN_PSURF = 1.0E+04  !   [m] default = 1.0E+04
-                                ! The length scale at which the Rayleigh damping rate due
-                                ! to the ice strength should be the same as if a Laplacian
-                                ! were applied, if DYNAMIC_SURFACE_PRESSURE is true.
+                                ! The length scale at which the Rayleigh damping rate due to the ice strength
+                                ! should be the same as if a Laplacian were applied, if DYNAMIC_SURFACE_PRESSURE
+                                ! is true.
 DEPTH_MIN_DYN_PSURF = 1.0E-06   !   [m] default = 1.0E-06
-                                ! The minimum depth to use in limiting the size of the
-                                ! dynamic surface pressure for stability, if
-                                ! DYNAMIC_SURFACE_PRESSURE is true..
+                                ! The minimum depth to use in limiting the size of the dynamic surface pressure
+                                ! for stability, if DYNAMIC_SURFACE_PRESSURE is true..
 CONST_DYN_PSURF = 0.9           !   [nondim] default = 0.9
-                                ! The constant that scales the dynamic surface pressure,
-                                ! if DYNAMIC_SURFACE_PRESSURE is true.  Stable values
-                                ! are < ~1.0.
+                                ! The constant that scales the dynamic surface pressure, if
+                                ! DYNAMIC_SURFACE_PRESSURE is true.  Stable values are < ~1.0.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1313,53 +1178,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1369,483 +1225,428 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
-FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
                                 ! streamfunction formulation.
+FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
                                 ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary
-                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
+                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.5E-06             !   [m2 s-1] default = 1.5E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
-                                ! When the Polzin decay profile is used, this is a
-                                ! non-dimensional constant in the expression for the
-                                ! vertical scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
-                                ! When the Polzin decay profile is used, this is the
-                                ! reference value of the buoyancy frequency at the ocean
-                                ! bottom in the Polzin formulation for the vertical
-                                ! scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a
-                                ! scale factor for the vertical scale of decay of the tidal
-                                ! energy dissipation.
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
 POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a factor
-                                ! to limit the vertical scale of decay of the tidal
-                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
-                                ! times the depth of the ocean.
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
 POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
-                                ! When the Polzin decay profile is used, this is the
-                                ! minimum vertical decay scale for the vertical profile
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
                                 ! of internal tide dissipation with the Polzin (2009) formulation
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v2015.12.03.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.643167672515498E-05 !   [m] default = 1.643167672515498E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.5E-05                  !   [m2 s-1] default = 1.5E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.5E-05      !   [m2 s-1] default = 1.5E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = True   !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = True !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -1854,101 +1655,91 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -1961,67 +1752,61 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching stable
+                                ! Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.v2015.12.03.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -2038,99 +1823,89 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2142,124 +1917,110 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.v2015.12.03.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_MEAN_DENSITY = 900.0    !   [kg m-3] default = 900.0
-                                ! A typical density of sea ice, used with the kinematic
-                                ! viscosity, when USE_RIGID_SEA_ICE is true.
+                                ! A typical density of sea ice, used with the kinematic viscosity, when
+                                ! USE_RIGID_SEA_ICE is true.
 SEA_ICE_VISCOSITY = 1.0E+09     !   [m2 s-1] default = 1.0E+09
-                                ! The kinematic viscosity of sufficiently thick sea ice
-                                ! for use in calculating the rigidity of sea ice.
+                                ! The kinematic viscosity of sufficiently thick sea ice for use in calculating
+                                ! the rigidity of sea ice.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -5,79 +5,68 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1.08E+04             !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 49                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 53                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -93,8 +82,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -133,17 +122,17 @@ TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -158,15 +147,14 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
@@ -199,9 +187,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -210,14 +197,11 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -239,9 +223,8 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -265,59 +248,52 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -333,13 +309,12 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
@@ -347,86 +322,74 @@ MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -436,23 +399,21 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -460,152 +421,127 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
+                                ! streamfunction formulation.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -614,37 +550,35 @@ EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v2015.12.03.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -653,56 +587,49 @@ H2_FILE = "ocean_topog.nc"      !
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -713,15 +640,15 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = True   !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = True !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -730,50 +657,46 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -786,29 +709,27 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.v2015.12.03.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -823,15 +744,13 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
 KHTR = 200.0                    !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
@@ -840,40 +759,36 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.v2015.12.03.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
@@ -881,11 +796,11 @@ CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 49                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 53                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 588.986572265625 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -486,12 +484,10 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 2, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
@@ -16,13 +16,11 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 49                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 53                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -33,8 +31,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -153,6 +151,5 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 7200.0      !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 1440                 !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 1080                 !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 1080                 !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = "All_edits.nc" ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,8 +260,8 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
-                                ! If true, the channel configuration list works for any
-                                ! longitudes in the range of -360 to 360.
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -299,54 +271,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -366,8 +333,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -377,27 +344,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -423,16 +388,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -443,12 +406,10 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -459,14 +420,11 @@ INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -488,12 +446,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -517,43 +473,38 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -564,48 +515,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = ""      ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "woa13_decav_ptemp_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "woa13_decav_s_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "ptemp_an" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -615,45 +558,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -667,8 +607,7 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
                                 !                by a comma or space, for sigma-2 and dz. e.g.
                                 !                HYBRID:vgrid.nc,sigma2,dz
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -684,53 +623,49 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -738,320 +673,279 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -1059,50 +953,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1112,206 +1000,172 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 ICE_LENGTH_DYN_PSURF = 1.0E+04  !   [m] default = 1.0E+04
-                                ! The length scale at which the Rayleigh damping rate due
-                                ! to the ice strength should be the same as if a Laplacian
-                                ! were applied, if DYNAMIC_SURFACE_PRESSURE is true.
+                                ! The length scale at which the Rayleigh damping rate due to the ice strength
+                                ! should be the same as if a Laplacian were applied, if DYNAMIC_SURFACE_PRESSURE
+                                ! is true.
 DEPTH_MIN_DYN_PSURF = 1.0E-06   !   [m] default = 1.0E-06
-                                ! The minimum depth to use in limiting the size of the
-                                ! dynamic surface pressure for stability, if
-                                ! DYNAMIC_SURFACE_PRESSURE is true..
+                                ! The minimum depth to use in limiting the size of the dynamic surface pressure
+                                ! for stability, if DYNAMIC_SURFACE_PRESSURE is true..
 CONST_DYN_PSURF = 0.9           !   [nondim] default = 0.9
-                                ! The constant that scales the dynamic surface pressure,
-                                ! if DYNAMIC_SURFACE_PRESSURE is true.  Stable values
-                                ! are < ~1.0.
+                                ! The constant that scales the dynamic surface pressure, if
+                                ! DYNAMIC_SURFACE_PRESSURE is true.  Stable values are < ~1.0.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1321,53 +1175,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1377,473 +1222,418 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 500.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.5E-06             !   [m2 s-1] default = 1.5E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
-                                ! When the Polzin decay profile is used, this is a
-                                ! non-dimensional constant in the expression for the
-                                ! vertical scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
-                                ! When the Polzin decay profile is used, this is the
-                                ! reference value of the buoyancy frequency at the ocean
-                                ! bottom in the Polzin formulation for the vertical
-                                ! scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a
-                                ! scale factor for the vertical scale of decay of the tidal
-                                ! energy dissipation.
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
 POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a factor
-                                ! to limit the vertical scale of decay of the tidal
-                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
-                                ! times the depth of the ocean.
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
 POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
-                                ! When the Polzin decay profile is used, this is the
-                                ! minimum vertical decay scale for the vertical profile
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
                                 ! of internal tide dissipation with the Polzin (2009) formulation
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v20140616.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.161895003862225E-05 !   [m] default = 1.161895003862225E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.5E-05                  !   [m2 s-1] default = 1.5E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.5E-05      !   [m2 s-1] default = 1.5E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -1852,101 +1642,91 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -1959,67 +1739,61 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching stable
+                                ! Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs-clim-1997-2010.1440x1080.v20180328.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -2036,89 +1810,81 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2130,124 +1896,110 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore_PHC2.1440x1080.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_MEAN_DENSITY = 900.0    !   [kg m-3] default = 900.0
-                                ! A typical density of sea ice, used with the kinematic
-                                ! viscosity, when USE_RIGID_SEA_ICE is true.
+                                ! A typical density of sea ice, used with the kinematic viscosity, when
+                                ! USE_RIGID_SEA_ICE is true.
 SEA_ICE_VISCOSITY = 1.0E+09     !   [m2 s-1] default = 1.0E+09
-                                ! The kinematic viscosity of sufficiently thick sea ice
-                                ! for use in calculating the rigidity of sea ice.
+                                ! The kinematic viscosity of sufficiently thick sea ice for use in calculating
+                                ! the rigidity of sea ice.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 32                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 18                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 32, 18                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 2, 2                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -5,85 +5,73 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 1440                 !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 1080                 !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -99,8 +87,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -141,17 +129,17 @@ TOPO_EDITS_FILE = "All_edits.nc" ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -170,14 +158,13 @@ CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
 
 ! === module MOM_EOS ===
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
@@ -207,9 +194,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -218,14 +204,11 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -247,9 +230,8 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -273,10 +255,9 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -288,42 +269,35 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = ""      ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "woa13_decav_ptemp_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "woa13_decav_s_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "ptemp_an" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -339,90 +313,78 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -432,23 +394,21 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -456,140 +416,117 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 MLE_FRONT_LENGTH = 500.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -598,37 +535,35 @@ EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.v20140616.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -637,56 +572,49 @@ H2_FILE = "ocean_topog.nc"      !
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -697,9 +625,9 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -708,50 +636,46 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -764,29 +688,27 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs-clim-1997-2010.1440x1080.v20180328.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 PEN_SW_NBANDS = 3               ! default = 1
@@ -801,53 +723,47 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
 
 ! === module MOM_tracer_hor_diff ===
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore_PHC2.1440x1080.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
@@ -855,11 +771,11 @@ CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
@@ -128,16 +128,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 1440                 !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 1080                 !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -148,8 +146,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -158,8 +156,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -180,13 +178,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 9682.232421875 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -207,12 +205,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -492,12 +490,10 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 32                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 18                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 32, 18                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 2, 2                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
@@ -16,16 +16,14 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 1440                 !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 1080                 !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -36,8 +34,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -147,6 +145,5 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 7200.0      !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 720                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 576                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 576                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,8 +260,8 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
-                                ! If true, the channel configuration list works for any
-                                ! longitudes in the range of -360 to 360.
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -299,54 +271,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -366,8 +333,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -377,27 +344,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -423,16 +388,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -443,12 +406,10 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -459,14 +420,11 @@ INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -488,12 +446,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -517,43 +473,38 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -564,48 +515,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = ""      ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "woa13_decav_ptemp_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "woa13_decav_s_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "ptemp_an" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -615,45 +558,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -667,8 +607,7 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
                                 !                by a comma or space, for sigma-2 and dz. e.g.
                                 !                HYBRID:vgrid.nc,sigma2,dz
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -684,53 +623,49 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.5             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.5             !   [nondim] default = 0.0
@@ -738,323 +673,282 @@ MEKE_KHTR_FAC = 0.5             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 1.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 RESOLN_N2_FILTER_DEPTH = 2000.0 !   [m] default = 2000.0
-                                ! The depth below which N2 is monotonized to avoid stratification
-                                ! artifacts from altering the equivalent barotropic mode structure.
+                                ! The depth below which N2 is monotonized to avoid stratification artifacts from
+                                ! altering the equivalent barotropic mode structure.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 100         !   [nondim] default = 100
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -1062,50 +956,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1115,212 +1003,177 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 KH_PWR_OF_SINE = 4.0            !   [nondim] default = 4.0
-                                ! The power used to raise SIN(LAT) when using a latitudinally-
-                                ! dependent background viscosity.
+                                ! The power used to raise SIN(LAT) when using a latitudinally dependent
+                                ! background viscosity.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 ICE_LENGTH_DYN_PSURF = 1.0E+04  !   [m] default = 1.0E+04
-                                ! The length scale at which the Rayleigh damping rate due
-                                ! to the ice strength should be the same as if a Laplacian
-                                ! were applied, if DYNAMIC_SURFACE_PRESSURE is true.
+                                ! The length scale at which the Rayleigh damping rate due to the ice strength
+                                ! should be the same as if a Laplacian were applied, if DYNAMIC_SURFACE_PRESSURE
+                                ! is true.
 DEPTH_MIN_DYN_PSURF = 1.0E-06   !   [m] default = 1.0E-06
-                                ! The minimum depth to use in limiting the size of the
-                                ! dynamic surface pressure for stability, if
-                                ! DYNAMIC_SURFACE_PRESSURE is true..
+                                ! The minimum depth to use in limiting the size of the dynamic surface pressure
+                                ! for stability, if DYNAMIC_SURFACE_PRESSURE is true..
 CONST_DYN_PSURF = 0.9           !   [nondim] default = 0.9
-                                ! The constant that scales the dynamic surface pressure,
-                                ! if DYNAMIC_SURFACE_PRESSURE is true.  Stable values
-                                ! are < ~1.0.
+                                ! The constant that scales the dynamic surface pressure, if
+                                ! DYNAMIC_SURFACE_PRESSURE is true.  Stable values are < ~1.0.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1330,53 +1183,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1386,483 +1230,428 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
-FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
                                 ! streamfunction formulation.
+FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
                                 ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary
-                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
+                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.5E-06             !   [m2 s-1] default = 1.5E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
-                                ! When the Polzin decay profile is used, this is a
-                                ! non-dimensional constant in the expression for the
-                                ! vertical scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
-                                ! When the Polzin decay profile is used, this is the
-                                ! reference value of the buoyancy frequency at the ocean
-                                ! bottom in the Polzin formulation for the vertical
-                                ! scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a
-                                ! scale factor for the vertical scale of decay of the tidal
-                                ! energy dissipation.
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
 POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a factor
-                                ! to limit the vertical scale of decay of the tidal
-                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
-                                ! times the depth of the ocean.
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
 POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
-                                ! When the Polzin decay profile is used, this is the
-                                ! minimum vertical decay scale for the vertical profile
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
                                 ! of internal tide dissipation with the Polzin (2009) formulation
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.643167672515498E-05 !   [m] default = 1.643167672515498E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.5E-05                  !   [m2 s-1] default = 1.5E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.5E-05      !   [m2 s-1] default = 1.5E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -1871,101 +1660,91 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -1978,67 +1757,61 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching stable
+                                ! Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs-clim-1997-2010.720x576.v20180328.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -2055,99 +1828,89 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 30.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2159,124 +1922,110 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore_PHC2.720x576.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_MEAN_DENSITY = 900.0    !   [kg m-3] default = 900.0
-                                ! A typical density of sea ice, used with the kinematic
-                                ! viscosity, when USE_RIGID_SEA_ICE is true.
+                                ! A typical density of sea ice, used with the kinematic viscosity, when
+                                ! USE_RIGID_SEA_ICE is true.
 SEA_ICE_VISCOSITY = 1.0E+09     !   [m2 s-1] default = 1.0E+09
-                                ! The kinematic viscosity of sufficiently thick sea ice
-                                ! for use in calculating the rigidity of sea ice.
+                                ! The kinematic viscosity of sufficiently thick sea ice for use in calculating
+                                ! the rigidity of sea ice.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 21                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 20                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 21, 20                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -5,80 +5,69 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 720                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 576                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -94,8 +83,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -134,17 +123,17 @@ TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -159,15 +148,14 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
@@ -200,9 +188,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -211,14 +198,11 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -240,9 +224,8 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -266,10 +249,9 @@ MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
 !MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
                                 ! The list of maximum thickness for each layer.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -281,42 +263,35 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = ""      ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "woa13_decav_ptemp_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "woa13_decav_s_monthly_fulldepth_01.nc" ! default = ""
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "ptemp_an" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -332,13 +307,12 @@ DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default 
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KHTH_FAC = 0.5             !   [nondim] default = 0.0
@@ -348,91 +322,78 @@ MEKE_KHTR_FAC = 0.5             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_VISCOSITY_COEFF = 1.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -442,23 +403,21 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -466,160 +425,134 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
+                                ! streamfunction formulation.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -628,37 +561,35 @@ EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "ocean_topog.nc"      !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -667,56 +598,49 @@ H2_FILE = "ocean_topog.nc"      !
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.5E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -727,9 +651,9 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 2                  !   [units=nondim] default = 0
@@ -738,50 +662,46 @@ MSTAR_MODE = 2                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 0.0                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.06                    !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 TKE_DECAY = 0.01                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 USE_LA_LI2016 = True            !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 LT_ENHANCE = 3                  !   [nondim] default = 0
                                 ! Integer for Langmuir number mode.
                                 !  *Requires USE_LA_LI2016 to be set to True.
@@ -794,29 +714,27 @@ LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
 LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
-                                ! Coefficient for modification of Langmuir number due to
-                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
+                                ! depth if LT_ENHANCE=2.
 LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! stable Obukhov depth if LT_ENHANCE=2.
 LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
-                                ! Coefficient for modification of Langmuir number due to
-                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+                                ! Coefficient for modification of Langmuir number due to ratio of Ekman to
+                                ! unstable Obukhov depth if LT_ENHANCE=2.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs-clim-1997-2010.720x576.v20180328.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 PEN_SW_NBANDS = 3               ! default = 1
@@ -833,15 +751,13 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
 KHTR = 50.0                     !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
@@ -850,47 +766,42 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 30.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 FLUXCONST = 0.1667              !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore_PHC2.720x576.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
@@ -898,11 +809,11 @@ CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice
-                                ! starts to exhibit rigidity
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
@@ -128,16 +128,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 720                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 576                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -148,8 +146,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -158,8 +156,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -180,13 +178,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 8799.6513671875 !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -207,12 +205,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -488,12 +486,10 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 21                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 20                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 21, 20                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
@@ -16,16 +16,14 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 720                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 576                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -36,8 +34,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,6 +154,5 @@ ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,20 +416,18 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -493,12 +455,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -525,8 +486,8 @@ SALT_IC_VAR = "SALT"            ! default = "SALT"
 SALT_FILE = "GOLD_IC.2010.11.15.nc" ! default = "GOLD_IC.2010.11.15.nc"
                                 ! The initial condition file for salinity.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -536,41 +497,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -586,285 +544,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -872,50 +787,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -925,186 +834,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1114,53 +993,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1170,563 +1040,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1743,93 +1543,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "B"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1841,118 +1632,103 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "B"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 999.0      !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -82,8 +70,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -120,14 +108,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -183,8 +171,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -212,12 +200,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -244,92 +231,81 @@ TS_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -340,57 +316,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -400,28 +365,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -433,97 +394,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -536,55 +488,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -598,74 +543,63 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 OCEAN_SURFACE_STAGGER = "B"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 WIND_STAGGER = "B"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -455,12 +453,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.debugging
@@ -24,8 +24,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 1                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 1                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
@@ -16,16 +16,14 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -36,8 +34,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -116,6 +114,5 @@ RECATEGORIZE_ICE = False        !   [Boolean] default = True
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,20 +416,18 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -493,12 +455,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -525,8 +486,8 @@ SALT_IC_VAR = "SALT"            ! default = "SALT"
 SALT_FILE = "GOLD_IC.2010.11.15.nc" ! default = "GOLD_IC.2010.11.15.nc"
                                 ! The initial condition file for salinity.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -536,41 +497,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -586,285 +544,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -872,50 +787,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -925,186 +834,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1114,53 +993,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1170,563 +1040,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1743,93 +1543,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1841,118 +1632,103 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 999.0      !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -82,8 +70,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -120,14 +108,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -183,8 +171,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -212,12 +200,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -244,92 +231,81 @@ TS_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -340,57 +316,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -400,28 +365,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -433,97 +394,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -536,55 +488,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -598,65 +543,56 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
@@ -128,16 +128,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -148,8 +146,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -158,8 +156,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -180,13 +178,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -207,12 +205,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -492,12 +490,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 60                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 60, 1                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
@@ -16,16 +16,14 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -36,8 +34,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -114,6 +112,5 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +178,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +215,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +248,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +310,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = True           !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,32 +321,30 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_OCMIP2_CFC ===
 CFC_IC_FILE = ""                ! default = ""
-                                ! The file in which the CFC initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the CFC initial values can be found, or an empty string for
+                                ! internal initialization.
 CFC_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, CFC_IC_FILE is in depth space, not layer space
 CFC11_A1 = 3501.8               !   [nondim] default = 3501.8
@@ -452,20 +416,18 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -493,12 +455,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -525,8 +486,8 @@ SALT_IC_VAR = "SALT"            ! default = "SALT"
 SALT_FILE = "GOLD_IC.2010.11.15.nc" ! default = "GOLD_IC.2010.11.15.nc"
                                 ! The initial condition file for salinity.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -536,41 +497,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -586,285 +544,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -872,50 +787,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -925,186 +834,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1114,53 +993,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1170,563 +1040,493 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REGULARIZE_SURFACE_DETRAIN = True !   [Boolean] default = True
-                                ! If true, allow the buffer layers to detrain into the
-                                ! interior as a part of the restructuring when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! If true, allow the buffer layers to detrain into the interior as a part of the
+                                ! restructuring when REGULARIZE_SURFACE_LAYERS is true.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1743,93 +1543,84 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -1841,118 +1632,103 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_NET_FW_ADJUSTMENT_SIGN_BUG = True !   [Boolean] default = True
-                                ! If true, use the wrong sign for the adjustment to
-                                ! the net fresh-water.
+                                ! If true, use the wrong sign for the adjustment to the net fresh-water.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
                                 ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
                                 ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
-                                ! If true, the restoring of salinity is applied as a salt
-                                ! flux instead of as a freshwater flux.
+                                ! If true, the restoring of salinity is applied as a salt flux instead of as a
+                                ! freshwater flux.
 MAX_DELTA_SRESTORE = 999.0      !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
-                                ! If true, disables SSS restoring under sea-ice based on a frazil
-                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+                                ! If true, disables SSS restoring under sea-ice based on a frazil criteria
+                                ! (SST<=Tf). Only used when RESTORE_SALINITY is True.
 MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
                                 ! If true, disable SSS restoring in marginal seas. Only used when
                                 ! RESTORE_SALINITY is True.
 BASIN_FILE = "basin.nc"         ! default = "basin.nc"
                                 ! A file in which to find the basin masks, in variable 'basin'.
 MASK_SRESTORE = False           !   [Boolean] default = False
-                                ! If true, read a file (salt_restore_mask) containing
-                                ! a mask for SSS restoring.
+                                ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -82,8 +70,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -120,14 +108,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -183,8 +171,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -212,12 +200,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -244,92 +231,81 @@ TS_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -340,57 +316,46 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -400,28 +365,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -433,97 +394,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -536,55 +488,48 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = True !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -598,65 +543,56 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 7.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = True         !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 USE_LIMITED_PATM_SSH = False    !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 CD_TIDES = 0.0025               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 6000.0         !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -490,12 +488,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
@@ -14,16 +14,14 @@ ADD_DIURNAL_SW = True           !   [Boolean] default = False
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -34,8 +32,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -117,6 +115,5 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 320                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 320                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,8 +260,8 @@ CHANNEL_CONFIG = "list"         ! default = "none"
 CHANNEL_LIST_FILE = "MOM_channels_FLOR" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
-                                ! If true, the channel configuration list works for any
-                                ! longitudes in the range of -360 to 360.
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -299,42 +271,40 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "MILLERO_78"     ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -354,8 +324,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -365,27 +335,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -411,16 +379,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -431,8 +397,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid_75_2m.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -452,46 +417,40 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid_75_2m.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -502,48 +461,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -553,45 +504,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000144" ! default = "available_diags.000144"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -607,53 +555,49 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -661,320 +605,279 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -982,50 +885,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1035,197 +932,164 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1235,53 +1099,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = True           !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1291,459 +1146,406 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 0.0          !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 0.0        !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_DENSITY_DIFF = 0.03         !   [kg/m3] default = 0.03
-                                ! Density difference used to detect the mixed-layer
-                                ! depth used for the mixed-layer eddy parameterization
-                                ! by Fox-Kemper et al. (2010)
+                                ! Density difference used to detect the mixed-layer depth used for the
+                                ! mixed-layer eddy parameterization by Fox-Kemper et al. (2010)
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "vgrid_75_2m.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
-                                ! When the Polzin decay profile is used, this is a
-                                ! non-dimensional constant in the expression for the
-                                ! vertical scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
-                                ! When the Polzin decay profile is used, this is the
-                                ! reference value of the buoyancy frequency at the ocean
-                                ! bottom in the Polzin formulation for the vertical
-                                ! scale of decay for the tidal energy dissipation.
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a
-                                ! scale factor for the vertical scale of decay of the tidal
-                                ! energy dissipation.
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
 POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
-                                ! When the Polzin decay profile is used, this is a factor
-                                ! to limit the vertical scale of decay of the tidal
-                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
-                                ! times the depth of the ocean.
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
 POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
-                                ! When the Polzin decay profile is used, this is the
-                                ! minimum vertical decay scale for the vertical profile
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
                                 ! of internal tide dissipation with the Polzin (2009) formulation
 INT_TIDE_DECAY_SCALE = 500.0    !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "topog.nc"            !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.897366596101028E-05 !   [m] default = 1.897366596101028E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1752,150 +1554,134 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -1912,83 +1698,76 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = False           !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module ocean_model_init ===
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false,
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false, the two phases are advanced with separate
+                                ! calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file.  A restart file
-                                ! will be saved at the end of the run segment for any
-                                ! non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file.  A
+                                ! restart file will be saved at the end of the run segment for any non-negative
+                                ! value.
 OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the surface
+                                ! velocity field that is returned to the coupler.  Valid values include 'A',
+                                ! 'B', or 'C'.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
@@ -2000,87 +1779,76 @@ LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 MAX_P_SURF = 3.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 RESTORE_SALINITY = False        !   [Boolean] default = False
-                                ! If true, the coupled driver will add a globally-balanced
-                                ! fresh-water flux that drives sea-surface salinity
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a globally-balanced fresh-water flux that
+                                ! drives sea-surface salinity toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
-                                ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperature
-                                ! toward specified values.
+                                ! If true, the coupled driver will add a  heat flux that drives sea-surface
+                                ! temperature toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the salinity restoring seen to zero
-                                ! whether restoring is via a salt flux or virtual precip.
+                                ! If true, adjusts the salinity restoring seen to zero whether restoring is via
+                                ! a salt flux or virtual precip.
 ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to salt restoring to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to salt restoring to achieve zero net are made by scaling
+                                ! values without moving the zero contour.
 ADJUST_NET_FRESH_WATER_TO_ZERO = False !   [Boolean] default = False
-                                ! If true, adjusts the net fresh-water forcing seen
-                                ! by the ocean (including restoring) to zero.
+                                ! If true, adjusts the net fresh-water forcing seen by the ocean (including
+                                ! restoring) to zero.
 ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
-                                ! If true, adjustments to net fresh water to achieve zero net are
-                                ! made by scaling values without moving the zero contour.
+                                ! If true, adjustments to net fresh water to achieve zero net are made by
+                                ! scaling values without moving the zero contour.
 ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
-                                ! The assumed sea-ice salinity needed to reverse engineer the
-                                ! melt flux (or ice-ocean fresh-water flux).
+                                ! The assumed sea-ice salinity needed to reverse engineer the melt flux (or
+                                ! ice-ocean fresh-water flux).
 USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
-                                ! If true, return the sea surface height with the
-                                ! correction for the atmospheric (and sea-ice) pressure
-                                ! limited by max_p_surf instead of the full atmospheric
+                                ! If true, return the sea surface height with the correction for the atmospheric
+                                ! (and sea-ice) pressure limited by max_p_surf instead of the full atmospheric
                                 ! pressure.
 APPROX_NET_MASS_SRC = False     !   [Boolean] default = False
-                                ! If true, use the net mass sources from the ice-ocean
-                                ! boundary type without any further adjustments to drive
-                                ! the ocean dynamics.  The actual net mass source may differ
-                                ! due to internal corrections.
+                                ! If true, use the net mass sources from the ice-ocean boundary type without any
+                                ! further adjustments to drive the ocean dynamics.  The actual net mass source
+                                ! may differ due to internal corrections.
 WIND_STAGGER = "C"              ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the input wind stress field.  Valid
-                                ! values are 'A', 'B', or 'C'.
+                                ! A case-insensitive character string to indicate the staggering of the input
+                                ! wind stress field.  Valid values are 'A', 'B', or 'C'.
 WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
-                                ! A factor multiplying the wind-stress given to the ocean by the
-                                ! coupler. This is used for testing and should be =1.0 for any
-                                ! production runs.
+                                ! A factor multiplying the wind-stress given to the ocean by the coupler. This
+                                ! is used for testing and should be =1.0 for any production runs.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
-                                ! If true, makes available diagnostics of fluxes from icebergs
-                                ! as seen by MOM6.
+                                ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
-                                ! If true, allows flux adjustments to specified via the
-                                ! data_table using the component name 'OCN'.
+                                ! If true, allows flux adjustments to specified via the data_table using the
+                                ! component name 'OCN'.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.debugging
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.layout
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 18                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 16                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 18, 16                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 2, 2                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -5,87 +5,74 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 1800.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 1800.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 WRITE_GEOM = 0                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 320                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -101,8 +88,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -139,17 +126,17 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -168,14 +155,13 @@ CHANNEL_LIST_FILE = "MOM_channels_FLOR" ! default = "MOM_channel_list"
 
 ! === module MOM_EOS ===
 TFREEZE_FORM = "MILLERO_78"     ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
@@ -205,9 +191,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -216,8 +201,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "FILE:vgrid_75_2m.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -237,10 +221,9 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid_75_2m.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -252,22 +235,18 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
@@ -275,79 +254,68 @@ Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
@@ -357,23 +325,21 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -381,19 +347,17 @@ CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -401,99 +365,80 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_STRONG_DRAG = True           !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "vgrid_75_2m.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -502,34 +447,32 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tidal_amplitude.nc" ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "topog.nc"            !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -538,44 +481,39 @@ H2_FILE = "topog.nc"            !
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -586,30 +524,28 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_energetic_PBL ===
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -622,38 +558,35 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
 
 ! === module MOM_tracer_hor_diff ===
 CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = False           !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
 MAX_P_SURF = 3.0E+04            !   [Pa] default = -1.0
-                                ! The maximum surface pressure that can be exerted by the
-                                ! atmosphere and floating sea-ice or ice shelves. This is
-                                ! needed because the FMS coupling structure does not
-                                ! limit the water that can be frozen out of the ocean and
-                                ! the ice-ocean heat fluxes are treated explicitly.  No
-                                ! limit is applied if a negative value is used.
+                                ! The maximum surface pressure that can be exerted by the atmosphere and
+                                ! floating sea-ice or ice shelves. This is needed because the FMS coupling
+                                ! structure does not limit the water that can be frozen out of the ocean and the
+                                ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
+                                ! negative value is used.
 CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
 

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
@@ -126,16 +126,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 320                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -146,8 +144,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -156,8 +154,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            ! default = "file"
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -178,13 +176,13 @@ TOPO_EDITS_FILE = ""            ! default = ""
 !MAXIMUM_DEPTH = 8317.21875     !   [m]
                                 ! The (diagnosed) maximum depth of the ocean.
 MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -205,12 +203,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.
@@ -486,12 +484,10 @@ ICE_DELTA_EDD_R_POND = 0.0      !   [nondimensional] default = 0.0
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in SIS_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in SIS_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in SIS_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! SIS_parameter_doc.short .

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.debugging
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.debugging
@@ -40,8 +40,6 @@ CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
                                 ! mass conservation in the sea-ice transport code.  This
                                 ! is expensive and should be used sparingly.
 REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.layout
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.layout
@@ -4,60 +4,55 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! that corresponding points on different processors have
                                 ! the same index. This does not work with static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NIHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in SIS2_memory.h at compile time;
+                                ! without STATIC_MEMORY_ the default is NJHALO_ in SIS2_memory.h (if defined) or
+                                ! 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 144                    !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in SIS2_memory.h at compile time.
 LAYOUT = 144, 1                 !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
@@ -11,16 +11,14 @@ CONSTANT_COSZEN_IC = 0.0        !   [nondim] default = -1.0
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 NJGLOBAL = 320                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in SIS2_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -31,8 +29,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -114,6 +112,5 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module MOM_file_parser ===
 DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -9,140 +9,117 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -150,16 +127,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -169,17 +144,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -189,8 +162,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -202,13 +175,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -245,13 +218,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -270,71 +243,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -354,8 +317,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,20 +350,18 @@ GFS = 9.80616                   !   [m s-2] default = 9.80616
 COORD_FILE = "isopyc_coords.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -426,8 +387,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -464,8 +425,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -475,41 +436,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -525,113 +483,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -641,82 +584,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -724,108 +655,93 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -837,449 +753,394 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = False           !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = False    !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.2        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1296,94 +1157,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1391,8 +1243,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1400,48 +1251,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1449,12 +1293,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -7,30 +7,25 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -40,10 +35,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -51,16 +45,16 @@ NK = 63                         !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -97,8 +91,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -106,24 +100,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,8 +147,8 @@ COORD_FILE = "isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -184,8 +174,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -218,62 +208,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -282,21 +264,19 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -306,12 +286,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -328,8 +307,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -338,9 +317,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -354,19 +332,17 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_regularize_layers ===
 
@@ -383,30 +359,27 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -414,30 +387,25 @@ GUST_CONST = 0.0                !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,337 +837,297 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1268,145 +1136,130 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1423,94 +1276,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1518,8 +1362,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1527,48 +1370,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1576,12 +1412,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,19 +306,17 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -354,8 +330,8 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -364,9 +340,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -380,20 +355,19 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -408,30 +382,27 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -439,30 +410,25 @@ GUST_CONST = 0.0                !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,123 +837,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1059,28 +955,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1088,21 +981,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1114,15 +1007,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1131,261 +1024,229 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1402,94 +1263,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1497,8 +1349,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1506,48 +1357,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1555,12 +1399,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,12 +306,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -342,8 +319,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
@@ -358,8 +335,8 @@ INTERP_TYPE = "cubic"           ! default = "quadratic"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -368,9 +345,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -384,15 +360,14 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -407,30 +382,27 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = -100.0     !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -438,30 +410,25 @@ GUST_CONST = 0.0                !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -9,140 +9,117 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -150,16 +127,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -169,17 +144,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -189,8 +162,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -202,13 +175,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -245,13 +218,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -270,71 +243,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -354,8 +317,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,20 +350,18 @@ GFS = 9.80616                   !   [m s-2] default = 9.80616
 COORD_FILE = "isopyc_coords.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -426,8 +387,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -464,8 +425,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -475,41 +436,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -525,113 +483,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -641,82 +584,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -724,108 +655,93 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -837,449 +753,394 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = False           !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = False    !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.2        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1296,91 +1157,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1388,8 +1240,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1397,48 +1248,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1446,12 +1290,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -7,30 +7,25 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -40,10 +35,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -51,16 +45,16 @@ NK = 63                         !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -97,8 +91,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -106,24 +100,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,8 +147,8 @@ COORD_FILE = "isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -184,8 +174,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -218,62 +208,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -282,21 +264,19 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -306,12 +286,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -328,8 +307,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -338,9 +317,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -354,19 +332,17 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_regularize_layers ===
 
@@ -383,27 +359,24 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -411,30 +384,25 @@ GUST_CONST = 0.05               !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,337 +837,297 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1268,145 +1136,130 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1423,91 +1276,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1515,8 +1359,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1524,48 +1367,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1573,12 +1409,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,19 +306,17 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -354,8 +330,8 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -364,9 +340,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -380,20 +355,19 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -408,27 +382,24 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -436,30 +407,25 @@ GUST_CONST = 0.05               !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,123 +837,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1059,28 +955,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1088,21 +981,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1114,15 +1007,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1131,261 +1024,229 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1402,91 +1263,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1494,8 +1346,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1503,48 +1354,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1552,12 +1396,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,12 +306,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -342,8 +319,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
@@ -358,8 +335,8 @@ INTERP_TYPE = "cubic"           ! default = "quadratic"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -368,9 +345,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -384,15 +360,14 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -407,27 +382,24 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.05               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -435,30 +407,25 @@ GUST_CONST = 0.05               !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -9,140 +9,117 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -150,16 +127,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -169,17 +144,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -189,8 +162,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -202,13 +175,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -245,13 +218,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -270,71 +243,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -354,8 +317,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,20 +350,18 @@ GFS = 9.80616                   !   [m s-2] default = 9.80616
 COORD_FILE = "isopyc_coords.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -426,8 +387,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -464,8 +425,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -475,41 +436,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -525,113 +483,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -641,82 +584,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -724,108 +655,93 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -837,449 +753,394 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = False           !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = False    !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.2        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1296,94 +1157,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1391,14 +1243,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1406,48 +1255,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1455,12 +1297,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -7,30 +7,25 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -40,10 +35,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -51,16 +45,16 @@ NK = 63                         !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -97,8 +91,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -106,24 +100,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,8 +147,8 @@ COORD_FILE = "isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -184,8 +174,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -216,62 +206,54 @@ SCM_L2_TEMP = 15.0              !   [C] default = 20.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -280,21 +262,19 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -304,12 +284,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -326,8 +305,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -336,9 +315,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -352,19 +330,17 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_regularize_layers ===
 
@@ -381,67 +357,57 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,337 +837,297 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1268,145 +1136,130 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1423,94 +1276,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1518,14 +1362,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1533,48 +1374,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1582,12 +1416,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -234,62 +223,54 @@ SCM_L2_TEMP = 15.0              !   [C] default = 20.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -298,25 +279,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -326,19 +304,17 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -352,8 +328,8 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -362,9 +338,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -378,20 +353,19 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -406,67 +380,57 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,123 +837,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1059,28 +955,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1088,21 +981,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1114,15 +1007,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1131,261 +1024,229 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1402,94 +1263,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1497,14 +1349,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1512,48 +1361,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1561,12 +1403,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -234,62 +223,54 @@ SCM_L2_TEMP = 15.0              !   [C] default = 20.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -298,25 +279,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -326,12 +304,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -340,8 +317,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
@@ -356,8 +333,8 @@ INTERP_TYPE = "cubic"           ! default = "quadratic"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -366,9 +343,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -382,15 +358,14 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -405,67 +380,57 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 100.0      !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -9,140 +9,117 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -150,16 +127,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -169,17 +144,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -189,8 +162,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -202,13 +175,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -245,13 +218,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -270,71 +243,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -354,8 +317,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,20 +350,18 @@ GFS = 9.80616                   !   [m s-2] default = 9.80616
 COORD_FILE = "isopyc_coords.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -426,8 +387,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -464,8 +425,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -475,41 +436,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -525,113 +483,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -641,82 +584,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -724,108 +655,93 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -837,449 +753,394 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = False           !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = False    !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.2        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1296,91 +1157,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1388,14 +1240,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1403,48 +1252,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1452,12 +1294,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -7,30 +7,25 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -40,10 +35,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -51,16 +45,16 @@ NK = 63                         !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -97,8 +91,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -106,24 +100,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,8 +147,8 @@ COORD_FILE = "isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -184,8 +174,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -218,62 +208,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -282,21 +264,19 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -306,12 +286,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -328,8 +307,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -338,9 +317,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -354,19 +332,17 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_regularize_layers ===
 
@@ -383,64 +359,54 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,337 +837,297 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1268,145 +1136,130 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1423,91 +1276,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1515,14 +1359,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1530,48 +1371,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1579,12 +1413,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,19 +306,17 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -354,8 +330,8 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -364,9 +340,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -380,20 +355,19 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -408,64 +382,54 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.80616                   !   [m s-2] default = 9.80616
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,123 +837,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1059,28 +955,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1088,21 +981,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1114,15 +1007,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1131,261 +1024,229 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1402,91 +1263,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1494,14 +1346,11 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1509,48 +1358,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1558,12 +1400,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.layout
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -7,33 +7,28 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -43,10 +38,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.80616               !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 400                        !   [nondim]
                                 ! The number of model layers.
 
@@ -54,16 +48,16 @@ NK = 400                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -100,8 +94,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -109,24 +103,20 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.764                 !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -153,9 +143,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +164,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "coord"      !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +191,8 @@ THICKNESS_CONFIG = "coord"      !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -236,62 +225,54 @@ SCM_L2_DTDZ = 0.01              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -300,25 +281,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -328,12 +306,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -342,8 +319,8 @@ Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
@@ -358,8 +335,8 @@ INTERP_TYPE = "cubic"           ! default = "quadratic"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -368,9 +345,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -384,15 +360,14 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -407,64 +382,54 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "const"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 CONST_WIND_TAUX = 0.1           !   [Pa]
-                                ! With wind_config const, this is the constant zonal
-                                ! wind-stress
+                                ! With wind_config const, this is the constant zonal wind-stress
 CONST_WIND_TAUY = 0.0           !   [Pa]
-                                ! With wind_config const, this is the constant meridional
-                                ! wind-stress
+                                ! With wind_config const, this is the constant meridional wind-stress
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -7,127 +7,108 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = False                 !   [Boolean] default = False
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 8.64E+04    !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -135,16 +116,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 150                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 70                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -154,17 +133,15 @@ NJGLOBAL = 70                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -174,8 +151,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -187,13 +164,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 700.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1500.0                 !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -232,38 +209,38 @@ MAXIMUM_DEPTH = 3600.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 1      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = True       !   [Boolean] default = False
                                 ! If true, sets relative vorticity to zero on open boundaries.
 OBC_FREESLIP_VORTICITY = False  !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the
+                                ! relative vorticity on open boundaries. This cannot be true if another
+                                ! OBC_XXX_VORTICITY option is True.
 OBC_COMPUTED_VORTICITY = False  !   [Boolean] default = False
-                                ! If true, uses the external values of tangential velocity
-                                ! in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, uses the external values of tangential velocity in the relative
+                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
+                                ! option is True.
 OBC_SPECIFIED_VORTICITY = False !   [Boolean] default = False
-                                ! If true, uses the external values of tangential velocity
-                                ! in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, uses the external values of tangential velocity in the relative
+                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
+                                ! option is True.
 OBC_ZERO_STRAIN = True          !   [Boolean] default = False
                                 ! If true, sets the strain used in the stress tensor to zero on open boundaries.
 OBC_FREESLIP_STRAIN = False     !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_COMPUTED_STRAIN = False     !   [Boolean] default = False
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_SPECIFIED_STRAIN = False    !   [Boolean] default = False
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_ZERO_BIHARMONIC = False     !   [Boolean] default = False
                                 ! If true, zeros the Laplacian of flow on open boundaries in the biharmonic
                                 ! viscosity term.
@@ -274,8 +251,8 @@ OBC_SEGMENT_001 = "J=N,I=110:100,SIMPLE" !
 BRUSHCUTTER_MODE = False        !   [Boolean] default = False
                                 ! If true, read external OBC data on the supergrid.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -294,18 +271,16 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_boundary_update ===
 USE_FILE_OBC = False            !   [Boolean] default = False
@@ -325,15 +300,15 @@ USE_DYED_CHANNEL_OBC = False    !   [Boolean] default = False
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -353,8 +328,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -364,13 +339,11 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module DOME_tracer ===
 DOME_TRACER_IC_FILE = ""        ! default = ""
-                                ! The name of a file from which to read the initial
-                                ! conditions for the DOME tracers, or blank to initialize
-                                ! them internally.
+                                ! The name of a file from which to read the initial conditions for the DOME
+                                ! tracers, or blank to initialize them internally.
 SPONGE = True                   !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified from MOM_initialization.F90.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified from MOM_initialization.F90.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "layer_ref"      !
@@ -403,12 +376,11 @@ DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "DOME"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -434,8 +406,8 @@ THICKNESS_CONFIG = "DOME"       !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -445,17 +417,16 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE_CONFIG = "DOME"          ! default = "file"
                                 ! A string that sets how the sponges are configured:
                                 !     file - read sponge properties from the file
@@ -469,8 +440,7 @@ SPONGE_CONFIG = "DOME"          ! default = "file"
 !Total sponge columns = 2400    !
                                 ! The total number of columns where sponges are applied.
 OBC_USER_CONFIG = "DOME"        ! default = "none"
-                                ! A string that sets how the user code is invoked to set open
-                                !  boundary data:
+                                ! A string that sets how the user code is invoked to set open boundary data:
                                 !    DOME - specified inflow on northern boundary
                                 !    dyed_channel - supercritical with dye on the inflow boundary
                                 !    dyed_obcs - circle_obcs with dyes on the open boundaries
@@ -482,23 +452,22 @@ OBC_USER_CONFIG = "DOME"        ! default = "none"
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -514,113 +483,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -628,106 +582,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.25E-09        !   [m] default = 1.25E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.25E-09    !   [m] default = 1.25E-09
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -735,28 +672,25 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = False         !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_Mont ===
 
@@ -764,168 +698,138 @@ ANALYTIC_FV_PGF = False         !   [Boolean] default = True
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 10.0       !   [m s-1] default = 10.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -935,53 +839,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -991,340 +886,300 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.0E-05             !   [m2 s-1] default = 1.0E-05
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 3.464101615137755E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 1.0E-06                !   [m2 s-1] default = 1.0E-06
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.0E-04      !   [m2 s-1] default = 1.0E-04
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1341,91 +1196,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1433,8 +1279,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1442,48 +1287,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 8.64E+04           !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 110.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1491,12 +1329,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/DOME/MOM_parameter_doc.debugging
+++ b/ocean_only/DOME/MOM_parameter_doc.debugging
@@ -7,51 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/DOME/MOM_parameter_doc.layout
+++ b/ocean_only/DOME/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 3                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 3, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -5,41 +5,33 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 DTBT_RESET_PERIOD = 8.64E+04    !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 150                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 70                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -47,10 +39,9 @@ NJGLOBAL = 70                   !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -60,8 +51,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -73,8 +64,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 700.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1500.0                 !   [k]
@@ -113,22 +104,22 @@ MAXIMUM_DEPTH = 3600.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 1      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = True       !   [Boolean] default = False
                                 ! If true, sets relative vorticity to zero on open boundaries.
 OBC_FREESLIP_VORTICITY = False  !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the
+                                ! relative vorticity on open boundaries. This cannot be true if another
+                                ! OBC_XXX_VORTICITY option is True.
 OBC_ZERO_STRAIN = True          !   [Boolean] default = False
                                 ! If true, sets the strain used in the stress tensor to zero on open boundaries.
 OBC_FREESLIP_STRAIN = False     !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_SEGMENT_001 = "J=N,I=110:100,SIMPLE" !
                                 ! Documentation needs to be dynamic?????
 ROTATION = "beta"               ! default = "2omegasinlat"
@@ -138,8 +129,7 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_boundary_update ===
 
@@ -153,9 +143,8 @@ USE_DOME_TRACER = True          !   [Boolean] default = False
 
 ! === module DOME_tracer ===
 SPONGE = True                   !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified from MOM_initialization.F90.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified from MOM_initialization.F90.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "layer_ref"      !
@@ -184,8 +173,8 @@ LIGHTEST_DENSITY = 1030.0       !   [kg m-3] default = 1031.0
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "DOME"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -223,8 +212,7 @@ SPONGE_CONFIG = "DOME"          ! default = "file"
 !Total sponge columns = 2400    !
                                 ! The total number of columns where sponges are applied.
 OBC_USER_CONFIG = "DOME"        ! default = "none"
-                                ! A string that sets how the user code is invoked to set open
-                                !  boundary data:
+                                ! A string that sets how the user code is invoked to set open boundary data:
                                 !    DOME - specified inflow on northern boundary
                                 !    dyed_channel - supercritical with dye on the inflow boundary
                                 !    dyed_obcs - circle_obcs with dyes on the open boundaries
@@ -242,32 +230,27 @@ OBC_USER_CONFIG = "DOME"        ! default = "none"
 
 ! === module MOM_set_visc ===
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
@@ -275,88 +258,72 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = False         !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_Mont ===
 
 ! === module MOM_hor_visc ===
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -381,8 +348,8 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 3.464101615137755E-05
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -391,18 +358,17 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 3.464101615137755E-05
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -428,49 +394,41 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 8.64E+04           !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 110.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -7,127 +7,108 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = False                 !   [Boolean] default = False
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 600.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1800.0               !   [s] default = 600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 8.64E+04    !   [s] default = 1800.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -135,16 +116,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 60                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -154,17 +133,15 @@ NJGLOBAL = 80                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 2                          !   [nondim]
                                 ! The number of model layers.
 
@@ -174,8 +151,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -187,13 +164,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1600.0                 !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1200.0                 !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -230,13 +207,13 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -255,18 +232,16 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 6.49E-05                  !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 2.0E-11                  !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -274,15 +249,15 @@ PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 50                 ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -302,8 +277,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -340,12 +315,11 @@ GINT = 0.0196                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "phillips"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -375,11 +349,10 @@ HALF_STRAT_DEPTH = 0.25         !   [nondim] default = 0.5
 JET_WIDTH = 200.0               !   [km]
                                 ! The width of the zonal-mean jet.
 JET_HEIGHT = 300.0              !   [m]
-                                ! The interface height scale associated with the
-                                ! zonal-mean jet.
+                                ! The interface height scale associated with the zonal-mean jet.
 VELOCITY_CONFIG = "phillips"    ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -391,21 +364,19 @@ VELOCITY_CONFIG = "phillips"    ! default = "zero"
 VELOCITY_IC_PERTURB_AMP = 0.001 !   [m s-1] default = 0.001
                                 ! The magnitude of the initial velocity perturbation.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = True                   !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 SPONGE_CONFIG = "phillips"      ! default = "file"
                                 ! A string that sets how the sponges are configured:
                                 !     file - read sponge properties from the file
@@ -423,23 +394,22 @@ SPONGE_RATE = 1.157407407407407E-06 !   [s-1] default = 1.157407407407407E-06
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -455,150 +425,128 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KH_RES_SCALE_COEF = 0.707106781 !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 0.707106781 !   [nondim] default = 0.707106781
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 100         !   [nondim] default = 100
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.01                    !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -606,106 +554,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-10         !   [m] default = 1.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-10     !   [m] default = 1.0E-10
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -713,28 +644,25 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = False         !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_Mont ===
 
@@ -742,168 +670,138 @@ ANALYTIC_FV_PGF = False         !   [Boolean] default = True
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 10.0       !   [m s-1] default = 10.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -913,53 +811,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 8000.0                   !   [m2 s-1] default = 0.0
@@ -969,340 +858,300 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.0E-05             !   [m2 s-1] default = 1.0E-05
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.449489742783178E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 1.0E-06                !   [m2 s-1] default = 1.0E-06
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.0E-04      !   [m2 s-1] default = 1.0E-04
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1319,91 +1168,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1411,8 +1251,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1420,48 +1259,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 730.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = -1.0                   !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1469,12 +1301,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.debugging
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.debugging
@@ -7,51 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.layout
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 4                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 16                     !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 4, 16                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -5,42 +5,33 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 DT = 600.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1800.0               !   [s] default = 600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 DTBT_RESET_PERIOD = 8.64E+04    !   [s] default = 1800.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 NIGLOBAL = 60                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -48,10 +39,9 @@ NJGLOBAL = 80                   !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 2                          !   [nondim]
                                 ! The number of model layers.
 
@@ -61,8 +51,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -74,8 +64,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1600.0                 !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1200.0                 !   [k]
@@ -112,8 +102,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -121,11 +111,9 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 6.49E-05                  !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 2.0E-11                  !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
@@ -162,8 +150,8 @@ GINT = 0.0196                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "phillips"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -193,11 +181,10 @@ HALF_STRAT_DEPTH = 0.25         !   [nondim] default = 0.5
 JET_WIDTH = 200.0               !   [km]
                                 ! The width of the zonal-mean jet.
 JET_HEIGHT = 300.0              !   [m]
-                                ! The interface height scale associated with the
-                                ! zonal-mean jet.
+                                ! The interface height scale associated with the zonal-mean jet.
 VELOCITY_CONFIG = "phillips"    ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -207,9 +194,8 @@ VELOCITY_CONFIG = "phillips"    ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 SPONGE = True                   !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 SPONGE_CONFIG = "phillips"      ! default = "file"
                                 ! A string that sets how the sponges are configured:
                                 !     file - read sponge properties from the file
@@ -231,59 +217,49 @@ SPONGE_RATE = 1.157407407407407E-06 !   [s-1] default = 1.157407407407407E-06
 
 ! === module MOM_lateral_mixing_coeffs ===
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KH_RES_SCALE_COEF = 0.707106781 !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 100           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.01                    !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
@@ -291,83 +267,68 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = False         !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_Mont ===
 
 ! === module MOM_hor_visc ===
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 8000.0                   !   [m2 s-1] default = 0.0
@@ -392,8 +353,8 @@ KHTH = 8000.0                   !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.449489742783178E-05
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -402,9 +363,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.449489742783178E-05
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 1.0E-06                !   [m2 s-1] default = 1.0E-06
                                 ! The minimum diapycnal diffusivity.
 
@@ -437,39 +397,33 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 730.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.81                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1027.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 600                        !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 2.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 300.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,71 +246,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 6.8103E-05                !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -356,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -387,13 +351,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.81                      !   [m s-2] default = 9.81
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -404,8 +367,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -425,46 +387,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -475,12 +431,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -506,8 +461,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +499,8 @@ SCM_L2_DSDZ = 0.0               !   [PPT/m] default = 0.0
 SCM_L2_MINTEMP = 4.0            !   [C] default = 4.0
                                 ! Layer 2 minimum temperature
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +510,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +561,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -725,82 +662,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -808,116 +733,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -929,120 +837,108 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = False !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1056,28 +952,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1085,21 +978,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1111,15 +1004,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1128,261 +1021,229 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1399,94 +1260,85 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "SCM_ideal_hurr"  !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1494,22 +1346,21 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module idealized_hurricane ===
 IDL_HURR_RHO_AIR = 1.2          !   [kg/m3] default = 1.2
-                                ! Air density used to compute the idealized hurricanewind profile.
+                                ! Air density used to compute the idealized hurricane wind profile.
 IDL_HURR_AMBIENT_PRESSURE = 1.012E+05 !   [Pa] default = 1.012E+05
                                 ! Ambient pressure used in the idealized hurricane wind profile.
 IDL_HURR_CENTRAL_PRESSURE = 9.68E+04 !   [Pa] default = 9.68E+04
                                 ! Central pressure used in the idealized hurricane wind profile.
 IDL_HURR_RAD_MAX_WIND = 5.0E+04 !   [m] default = 5.0E+04
-                                ! Radius of maximum winds used in theidealized hurricane wind profile.
+                                ! Radius of maximum winds used in the idealized hurricane wind profile.
 IDL_HURR_MAX_WIND = 65.0        !   [m/s] default = 65.0
                                 ! Maximum wind speed used in the idealized hurricanewind profile.
 IDL_HURR_TRAN_SPEED = 5.0       !   [m/s] default = 5.0
-                                ! Translation speed of hurricane used in the idealizedhurricane wind profile.
+                                ! Translation speed of hurricane used in the idealized hurricane wind profile.
 IDL_HURR_TRAN_DIR = 180.0       !   [degrees] default = 180.0
                                 ! Translation direction (towards) of hurricane used in the idealized hurricane
                                 ! wind profile.
@@ -1518,12 +1369,12 @@ IDL_HURR_X0 = 0.0               !   [m] default = 0.0
 IDL_HURR_Y0 = 0.0               !   [m] default = 0.0
                                 ! Idealized Hurricane initial Y position
 IDL_HURR_TAU_CURR_REL = False   ! default = False
-                                ! Current relative stress switchused in the idealized hurricane wind profile.
+                                ! Current relative stress switch used in the idealized hurricane wind profile.
 IDL_HURR_SCM_BR_BENCH = False   ! default = False
                                 ! Single column mode benchmark case switch, which is invoking a modification
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = False            ! default = False
-                                ! Single Column mode switchused in the SCM idealized hurricane wind profile.
+                                ! Single Column mode switch used in the SCM idealized hurricane wind profile.
 IDL_HURR_SCM_LOCY = 5.0E+04     !   [m] default = 5.0E+04
                                 ! Y distance of station used in the SCM idealized hurricane wind profile.
 
@@ -1533,48 +1384,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 3.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1582,12 +1426,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.debugging
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.layout
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -7,43 +7,36 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -53,10 +46,9 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.81                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1027.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 600                        !   [nondim]
                                 ! The number of model layers.
 
@@ -64,16 +56,16 @@ NK = 600                        !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 27.836               !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 2.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 2.0                    !   [degrees]
@@ -110,8 +102,8 @@ MAXIMUM_DEPTH = 300.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -119,20 +111,17 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 6.8103E-05                !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DS = 0.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -159,9 +148,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -181,8 +169,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -208,8 +196,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -244,62 +232,54 @@ SCM_L2_DTDZ = 0.04              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.0E-08
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -308,25 +288,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -343,13 +320,13 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 APPLY_NONLOCAL_TRANSPORT = False !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
@@ -363,8 +340,8 @@ INTERP_TYPE = "cubic"           ! default = "quadratic"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -373,9 +350,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-08
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -389,15 +365,14 @@ KD = 0.0                        !   [m2 s-1]
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 
@@ -412,26 +387,23 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "const"           !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
-                                ! A constant heat forcing (positive into ocean) applied
-                                ! through the sensible heat flux field.
+                                ! A constant heat forcing (positive into ocean) applied through the sensible
+                                ! heat flux field.
 WIND_CONFIG = "SCM_ideal_hurr"  !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.0                !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 
@@ -441,30 +413,25 @@ GUST_CONST = 0.0                !   [Pa] default = 0.02
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 3.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,11 +352,9 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1000.0       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 10.0                      !   [m s-2] default = 10.0
                                 ! The reduced gravity at the free surface.
 
@@ -402,12 +363,11 @@ GFS = 10.0                      !   [m s-2] default = 10.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -449,8 +409,8 @@ FRONT_WAVE_LENGTH = 0.0         !   [same as x,y] default = 0.0
 FRONT_WAVE_ASYM = 0.0           !   [not defined] default = 0.0
                                 ! Amplitude of frontal asymmetric perturbation
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -477,8 +437,8 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -488,41 +448,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -538,113 +495,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.01           !   [m] default = 0.01
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
@@ -652,106 +594,89 @@ KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -759,50 +684,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -812,162 +731,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 1.0E-10           !   [m] default = 1.0E-10
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -977,53 +869,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 1.0                 !   [m] default = 1.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1033,363 +916,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-13         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1406,91 +1246,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1498,8 +1329,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1507,48 +1337,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1556,12 +1379,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.layout
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -5,32 +5,25 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -40,13 +33,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -56,10 +47,9 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
@@ -71,8 +61,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -84,8 +74,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 64.0                   !   [k]
@@ -122,8 +112,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -135,17 +125,14 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -172,16 +159,15 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -217,8 +203,8 @@ DELTA_S_STRAT = 0.0             !   [1e-3]
 ADJUSTMENT_DELTAS = 5.0         !   [1e-3]
                                 ! Salinity difference across front
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -251,45 +237,40 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -302,53 +283,44 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -358,20 +330,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -396,22 +365,19 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -429,11 +395,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -444,65 +409,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1000.0       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 10.0                      !   [m s-2] default = 10.0
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,12 +374,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -430,14 +388,11 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -459,12 +414,10 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1000.0, 1000.2, 1000.4000000000001, 1000.6000000000001, 1000.8000000000002, 1001.0000000000002, 1001.2000000000003, 1001.4000000000003, 1001.6000000000004, 1001.8000000000004, 1002.0000000000005, 1002.2000000000005, 1002.4000000000005, 1002.6000000000006, 1002.8000000000006, 1003.0000000000007, 1003.2000000000007, 1003.4000000000008, 1003.6000000000008, 1003.8000000000009, 1004.0000000000009, 1004.200000000001, 1004.400000000001, 1004.600000000001, 1004.8000000000011, 1005.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "NONE" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -484,43 +437,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -531,12 +479,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -576,8 +523,8 @@ FRONT_WAVE_LENGTH = 0.0         !   [same as x,y] default = 0.0
 FRONT_WAVE_ASYM = 0.0           !   [not defined] default = 0.0
                                 ! Amplitude of frontal asymmetric perturbation
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -604,8 +551,8 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -615,45 +562,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -669,113 +613,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.01           !   [m] default = 0.01
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
@@ -783,106 +712,89 @@ KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -890,50 +802,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -943,162 +849,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 1.0E-10           !   [m] default = 1.0E-10
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1108,53 +987,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 1.0                 !   [m] default = 1.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1164,363 +1034,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-13         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1537,91 +1364,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1629,8 +1447,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1638,48 +1455,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1687,12 +1497,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.layout
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -5,28 +5,23 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -36,13 +31,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -52,10 +45,9 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
@@ -67,8 +59,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -80,8 +72,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 64.0                   !   [k]
@@ -118,8 +110,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -131,17 +123,14 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -168,12 +157,10 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -182,12 +169,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -198,11 +183,9 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 !ALE_RESOLUTION = 25*0.2        !   [kg m^-3]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
@@ -212,13 +195,11 @@ BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
 !TARGET_DENSITIES = 1000.0, 1000.2, 1000.4000000000001, 1000.6000000000001, 1000.8000000000002, 1001.0000000000002, 1001.2000000000003, 1001.4000000000003, 1001.6000000000004, 1001.8000000000004, 1002.0000000000005, 1002.2000000000005, 1002.4000000000005, 1002.6000000000006, 1002.8000000000006, 1003.0000000000007, 1003.2000000000007, 1003.4000000000008, 1003.6000000000008, 1003.8000000000009, 1004.0000000000009, 1004.200000000001, 1004.400000000001, 1004.600000000001, 1004.8000000000011, 1005.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -230,8 +211,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -265,8 +246,8 @@ DELTA_S_STRAT = 0.0             !   [1e-3]
 ADJUSTMENT_DELTAS = 5.0         !   [1e-3]
                                 ! Salinity difference across front
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -299,45 +280,40 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -350,53 +326,44 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -406,20 +373,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -444,22 +408,19 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -477,11 +438,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -492,65 +452,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1000.0       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 10.0                      !   [m s-2] default = 10.0
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,8 +374,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -435,46 +394,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -485,12 +438,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -530,8 +482,8 @@ FRONT_WAVE_LENGTH = 0.0         !   [same as x,y] default = 0.0
 FRONT_WAVE_ASYM = 0.0           !   [not defined] default = 0.0
                                 ! Amplitude of frontal asymmetric perturbation
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -558,8 +510,8 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -569,45 +521,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -623,113 +572,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.01           !   [m] default = 0.01
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
@@ -737,106 +671,89 @@ KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -844,50 +761,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -897,162 +808,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 1.0E-10           !   [m] default = 1.0E-10
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1062,53 +946,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 1.0                 !   [m] default = 1.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1118,363 +993,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-13         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1491,91 +1323,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1583,8 +1406,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1592,48 +1414,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1641,12 +1456,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.layout
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -5,28 +5,23 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 150.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 300.0                !   [s] default = 150.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -36,13 +31,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -52,10 +45,9 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
@@ -67,8 +59,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -80,8 +72,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 64.0                   !   [k]
@@ -118,8 +110,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -131,17 +123,14 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -168,12 +157,10 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -188,13 +175,11 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -206,8 +191,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "adjustment2d" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -241,8 +226,8 @@ DELTA_S_STRAT = 0.0             !   [1e-3]
 ADJUSTMENT_DELTAS = 5.0         !   [1e-3]
                                 ! Salinity difference across front
 TS_CONFIG = "adjustment2d"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -275,45 +260,40 @@ S_RANGE = 5.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.25E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -326,53 +306,44 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -382,20 +353,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -420,22 +388,19 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -453,11 +418,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -468,65 +432,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -7,146 +7,122 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -154,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 180                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -173,17 +147,15 @@ NJGLOBAL = 180                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 22                         !   [nondim]
                                 ! The number of model layers.
 
@@ -193,8 +165,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mercator"        !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -211,22 +183,20 @@ LENLON = 90.0                   !   [degrees]
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
                                 ! The radius of the Earth.
 ISOTROPIC = True                !   [Boolean] default = False
-                                ! If true, an isotropic grid on a sphere (also known as
-                                ! a Mercator grid) is used. With an isotropic grid, the
-                                ! meridional extent of the domain (LENLAT), the zonal
-                                ! extent (LENLON), and the number of grid points in each
-                                ! direction are _not_ independent. In MOM the meridional
-                                ! extent is determined to fit the zonal extent and the
-                                ! number of grid points, while grid is perfectly isotropic.
+                                ! If true, an isotropic grid on a sphere (also known as a Mercator grid) is
+                                ! used. With an isotropic grid, the meridional extent of the domain (LENLAT),
+                                ! the zonal extent (LENLON), and the number of grid points in each direction are
+                                ! _not_ independent. In MOM the meridional extent is determined to fit the zonal
+                                ! extent and the number of grid points, while grid is perfectly isotropic.
 EQUATOR_REFERENCE = True        !   [Boolean] default = True
-                                ! If true, the grid is defined to have the equator at the
-                                ! nearest q- or h- grid point to (-LOWLAT*NJGLOBAL/LENLAT).
+                                ! If true, the grid is defined to have the equator at the nearest q- or h- grid
+                                ! point to (-LOWLAT*NJGLOBAL/LENLAT).
 LAT_ENHANCE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! The amount by which the meridional resolution is
-                                ! enhanced within LAT_EQ_ENHANCE of the equator.
+                                ! The amount by which the meridional resolution is enhanced within
+                                ! LAT_EQ_ENHANCE of the equator.
 LAT_EQ_ENHANCE = 0.0            !   [degrees] default = 0.0
-                                ! The latitude range to the north and south of the equator
-                                ! over which the resolution is enhanced.
+                                ! The latitude range to the north and south of the equator over which the
+                                ! resolution is enhanced.
 TOPO_CONFIG = "benchmark"       !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,13 +231,13 @@ MAXIMUM_DEPTH = 5500.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -288,54 +258,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -355,8 +320,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -366,27 +331,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "ts_range"       !
@@ -410,23 +373,20 @@ COORD_CONFIG = "ts_range"       !
 T_REF = 10.0                    !   [degC] default = 10.0
                                 ! The default initial temperatures.
 TS_RANGE_T_LIGHT = 25.0         !   [degC] default = 10.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 3.0          !   [degC] default = 10.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 S_REF = 35.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 35.0         !   [PSU] default = 35.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.0         !   [PSU] default = 35.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_RESOLN_RATIO = 5.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
@@ -436,12 +396,11 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "benchmark"  !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -473,8 +432,8 @@ BENCHMARK_ML_DEPTH_IC = 50.0    !   [m] default = 50.0
 BENCHMARK_THERMOCLINE_SCALE = 500.0 !   [m] default = 500.0
                                 ! Initial thermocline depth scale in the benchmark test case.
 TS_CONFIG = "benchmark"         !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -493,8 +452,8 @@ TS_CONFIG = "benchmark"         !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -504,41 +463,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -554,172 +510,147 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = True       !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.1            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.1            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -727,106 +658,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 1.1E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 0.001      !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -834,212 +748,179 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 10.0       !   [m s-1] default = 10.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1049,53 +930,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0                      !   [m2 s-1] default = 0.0
@@ -1105,458 +977,400 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.341640786499874E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-07                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1573,148 +1387,126 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "linear"          !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "gyres"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 TAUX_CONST = 0.0                !   [Pa] default = 0.0
-                                ! With the gyres wind_config, the constant offset in the
-                                ! zonal wind stress profile:
-                                !   A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the constant offset in the zonal wind stress
+                                ! profile:   A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 TAUX_SIN_AMP = 0.1              !   [Pa] default = 0.0
-                                ! With the gyres wind_config, the sine amplitude in the
-                                ! zonal wind stress profile:
-                                !   B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the sine amplitude in the zonal wind stress
+                                ! profile:   B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 TAUX_COS_AMP = 0.0              !   [Pa] default = 0.0
-                                ! With the gyres wind_config, the cosine amplitude in
-                                ! the zonal wind stress profile:
-                                !   C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the cosine amplitude in the zonal wind stress
+                                ! profile:   C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 TAUX_N_PIS = 1.0                !   [nondim] default = 0.0
-                                ! With the gyres wind_config, the number of gyres in
-                                ! the zonal wind stress profile:
-                                !   n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the number of gyres in the zonal wind stress
+                                ! profile:   n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_T = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface temperature
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface temperature flux to the
+                                ! relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_S = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface salinity
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface salinity flux to the relative
+                                ! surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 SST_NORTH = 27.0                !   [deg C] default = 0.0
-                                ! With buoy_config linear, the sea surface temperature
-                                ! at the northern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface temperature at the northern end of
+                                ! the domain toward which to to restore.
 SST_SOUTH = 3.0                 !   [deg C] default = 0.0
-                                ! With buoy_config linear, the sea surface temperature
-                                ! at the southern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface temperature at the southern end of
+                                ! the domain toward which to to restore.
 SSS_NORTH = 35.0                !   [PSU] default = 35.0
-                                ! With buoy_config linear, the sea surface salinity
-                                ! at the northern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface salinity at the northern end of the
+                                ! domain toward which to to restore.
 SSS_SOUTH = 35.0                !   [PSU] default = 35.0
-                                ! With buoy_config linear, the sea surface salinity
-                                ! at the southern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface salinity at the southern end of the
+                                ! domain toward which to to restore.
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1722,48 +1514,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1771,12 +1556,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/benchmark/MOM_parameter_doc.debugging
+++ b/ocean_only/benchmark/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/benchmark/MOM_parameter_doc.layout
+++ b/ocean_only/benchmark/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 12                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 12, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -5,54 +5,44 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 180                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -68,8 +58,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mercator"        !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -82,13 +72,11 @@ LENLAT = 41.0                   !   [degrees]
 LENLON = 90.0                   !   [degrees]
                                 ! The longitudinal length of the domain.
 ISOTROPIC = True                !   [Boolean] default = False
-                                ! If true, an isotropic grid on a sphere (also known as
-                                ! a Mercator grid) is used. With an isotropic grid, the
-                                ! meridional extent of the domain (LENLAT), the zonal
-                                ! extent (LENLON), and the number of grid points in each
-                                ! direction are _not_ independent. In MOM the meridional
-                                ! extent is determined to fit the zonal extent and the
-                                ! number of grid points, while grid is perfectly isotropic.
+                                ! If true, an isotropic grid on a sphere (also known as a Mercator grid) is
+                                ! used. With an isotropic grid, the meridional extent of the domain (LENLAT),
+                                ! the zonal extent (LENLON), and the number of grid points in each direction are
+                                ! _not_ independent. In MOM the meridional extent is determined to fit the zonal
+                                ! extent and the number of grid points, while grid is perfectly isotropic.
 TOPO_CONFIG = "benchmark"       !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -123,8 +111,8 @@ MAXIMUM_DEPTH = 5500.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 
 ! === module MOM_tracer_registry ===
 
@@ -158,15 +146,14 @@ COORD_CONFIG = "ts_range"       !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 TS_RANGE_T_LIGHT = 25.0         !   [degC] default = 10.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 3.0          !   [degC] default = 10.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_RESOLN_RATIO = 5.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 
 ! === module MOM_grid ===
@@ -174,8 +161,8 @@ TS_RANGE_RESOLN_RATIO = 5.0     !   [nondim] default = 1.0
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "benchmark"  !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -203,8 +190,8 @@ THICKNESS_CONFIG = "benchmark"  !
 
 ! === module benchmark_initialize_thickness ===
 TS_CONFIG = "benchmark"         !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -229,89 +216,78 @@ TS_CONFIG = "benchmark"         !
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = True       !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.1            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.1            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 1.1E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 0.001      !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
@@ -319,56 +295,45 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0                      !   [m2 s-1] default = 0.0
@@ -378,19 +343,16 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 
@@ -409,8 +371,8 @@ FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.341640786499874E-05
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -419,18 +381,17 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.341640786499874E-05
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -441,50 +402,44 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -494,92 +449,76 @@ KHTR = 1.0                      !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "linear"          !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "gyres"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 TAUX_SIN_AMP = 0.1              !   [Pa] default = 0.0
-                                ! With the gyres wind_config, the sine amplitude in the
-                                ! zonal wind stress profile:
-                                !   B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the sine amplitude in the zonal wind stress
+                                ! profile:   B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 TAUX_N_PIS = 1.0                !   [nondim] default = 0.0
-                                ! With the gyres wind_config, the number of gyres in
-                                ! the zonal wind stress profile:
-                                !   n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
+                                ! With the gyres wind_config, the number of gyres in the zonal wind stress
+                                ! profile:   n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 SST_NORTH = 27.0                !   [deg C] default = 0.0
-                                ! With buoy_config linear, the sea surface temperature
-                                ! at the northern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface temperature at the northern end of
+                                ! the domain toward which to to restore.
 SST_SOUTH = 3.0                 !   [deg C] default = 0.0
-                                ! With buoy_config linear, the sea surface temperature
-                                ! at the southern end of the domain toward which to
-                                ! to restore.
+                                ! With buoy_config linear, the sea surface temperature at the southern end of
+                                ! the domain toward which to to restore.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -7,127 +7,108 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = False                 !   [Boolean] default = False
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 120.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 120.0                !   [s] default = 120.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 120.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -135,16 +116,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 25                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 25                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -154,17 +133,15 @@ NJGLOBAL = 25                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -174,8 +151,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -187,13 +164,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 100.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 100.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -230,38 +207,38 @@ MAXIMUM_DEPTH = 600.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 4      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = False      !   [Boolean] default = False
                                 ! If true, sets relative vorticity to zero on open boundaries.
 OBC_FREESLIP_VORTICITY = True   !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the
+                                ! relative vorticity on open boundaries. This cannot be true if another
+                                ! OBC_XXX_VORTICITY option is True.
 OBC_COMPUTED_VORTICITY = False  !   [Boolean] default = False
-                                ! If true, uses the external values of tangential velocity
-                                ! in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, uses the external values of tangential velocity in the relative
+                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
+                                ! option is True.
 OBC_SPECIFIED_VORTICITY = False !   [Boolean] default = False
-                                ! If true, uses the external values of tangential velocity
-                                ! in the relative vorticity on open boundaries. This cannot
-                                ! be true if another OBC_XXX_VORTICITY option is True.
+                                ! If true, uses the external values of tangential velocity in the relative
+                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
+                                ! option is True.
 OBC_ZERO_STRAIN = False         !   [Boolean] default = False
                                 ! If true, sets the strain used in the stress tensor to zero on open boundaries.
 OBC_FREESLIP_STRAIN = True      !   [Boolean] default = True
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_COMPUTED_STRAIN = False     !   [Boolean] default = False
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_SPECIFIED_STRAIN = False    !   [Boolean] default = False
-                                ! If true, sets the normal gradient of tangential velocity to
-                                ! zero in the strain use in the stress tensor on open boundaries. This cannot
-                                ! be true if another OBC_XXX_STRAIN option is True.
+                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
+                                ! use in the stress tensor on open boundaries. This cannot be true if another
+                                ! OBC_XXX_STRAIN option is True.
 OBC_ZERO_BIHARMONIC = True      !   [Boolean] default = False
                                 ! If true, zeros the Laplacian of flow on open boundaries in the biharmonic
                                 ! viscosity term.
@@ -286,26 +263,23 @@ OBC_SEGMENT_003_DATA = "U=value:0.0,V=value:0.0,SSH=value:0.0" !
 OBC_SEGMENT_004_DATA = "U=value:0.0,V=value:0.0,SSH=value:0.0" !
                                 ! OBC segment docs
 OBC_RADIATION_MAX = 10.0        !   [m s-1] default = 10.0
-                                ! The maximum magnitude of the baroclinic radiation
-                                ! velocity (or speed of characteristics).  This is only
-                                ! used if one of the open boundary segments is using Orlanski.
+                                ! The maximum magnitude of the baroclinic radiation velocity (or speed of
+                                ! characteristics).  This is only used if one of the open boundary segments is
+                                ! using Orlanski.
 OBC_RAD_VEL_WT = 0.3            !   [nondim] default = 0.3
-                                ! The relative weighting for the baroclinic radiation
-                                ! velocities (or speed of characteristics) at the new
-                                ! time level (1) or the running mean (0) for velocities.
-                                ! Valid values range from 0 to 1. This is only used if
-                                ! one of the open boundary segments is using Orlanski.
+                                ! The relative weighting for the baroclinic radiation velocities (or speed of
+                                ! characteristics) at the new time level (1) or the running mean (0) for
+                                ! velocities. Valid values range from 0 to 1. This is only used if one of the
+                                ! open boundary segments is using Orlanski.
 OBC_TRACER_RESERVOIR_LENGTH_SCALE_OUT = 0.0 !   [m] default = 0.0
-                                ! An effective length scale for restoring the tracer concentration
-                                ! at the boundaries to externally imposed values when the flow
-                                ! is exiting the domain.
+                                ! An effective length scale for restoring the tracer concentration at the
+                                ! boundaries to externally imposed values when the flow is exiting the domain.
 OBC_TRACER_RESERVOIR_LENGTH_SCALE_IN = 0.0 !   [m] default = 0.0
-                                ! An effective length scale for restoring the tracer concentration
-                                ! at the boundaries to values from the interior when the flow
-                                ! is entering the domain.
+                                ! An effective length scale for restoring the tracer concentration at the
+                                ! boundaries to values from the interior when the flow is entering the domain.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -324,18 +298,16 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_boundary_update ===
 USE_FILE_OBC = False            !   [Boolean] default = False
@@ -355,15 +327,15 @@ USE_DYED_CHANNEL_OBC = False    !   [Boolean] default = False
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -383,8 +355,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -394,13 +366,11 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module DOME_tracer ===
 DOME_TRACER_IC_FILE = ""        ! default = ""
-                                ! The name of a file from which to read the initial
-                                ! conditions for the DOME tracers, or blank to initialize
-                                ! them internally.
+                                ! The name of a file from which to read the initial conditions for the DOME
+                                ! tracers, or blank to initialize them internally.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified from MOM_initialization.F90.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified from MOM_initialization.F90.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "layer_ref"      !
@@ -433,12 +403,11 @@ DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "circle_obcs" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -466,17 +435,15 @@ THICKNESS_CONFIG = "circle_obcs" !
 
 ! === module circle_obcs_initialization ===
 DISK_RADIUS = 24.0              !   [kilometers]
-                                ! The radius of the initially elevated disk in the
-                                ! circle_obcs test case.
+                                ! The radius of the initially elevated disk in the circle_obcs test case.
 DISK_X_OFFSET = 0.0             !   [kilometers] default = 0.0
-                                ! The x-offset of the initially elevated disk in the
-                                ! circle_obcs test case.
+                                ! The x-offset of the initially elevated disk in the circle_obcs test case.
 DISK_IC_AMPLITUDE = 5.0         !   [m] default = 5.0
-                                ! Initial amplitude of interface height displacements
-                                ! in the circle_obcs test case.
+                                ! Initial amplitude of interface height displacements in the circle_obcs test
+                                ! case.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -486,20 +453,18 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 OBC_USER_CONFIG = "none"        ! default = "none"
-                                ! A string that sets how the user code is invoked to set open
-                                !  boundary data:
+                                ! A string that sets how the user code is invoked to set open boundary data:
                                 !    DOME - specified inflow on northern boundary
                                 !    dyed_channel - supercritical with dye on the inflow boundary
                                 !    dyed_obcs - circle_obcs with dyes on the open boundaries
@@ -511,23 +476,22 @@ OBC_USER_CONFIG = "none"        ! default = "none"
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -543,113 +507,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -657,106 +606,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 5.0E-10         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 5.0E-10     !   [m] default = 5.0E-10
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -764,50 +696,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -817,204 +743,170 @@ KH = 25.0                       !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 10.0       !   [m s-1] default = 10.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1024,53 +916,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1080,340 +963,300 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.0E-05             !   [m2 s-1] default = 1.0E-05
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.095445115010332E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 1.0E-06                !   [m2 s-1] default = 1.0E-06
                                 ! The minimum diapycnal diffusivity.
 KDML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 1.0E-04      !   [m2 s-1] default = 1.0E-04
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1430,91 +1273,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1522,8 +1356,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1531,48 +1364,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 120.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1580,12 +1406,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/circle_obcs/MOM_parameter_doc.debugging
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/circle_obcs/MOM_parameter_doc.layout
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -5,22 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 DT = 120.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 120.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -28,13 +24,11 @@ IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 25                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 25                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -42,10 +36,9 @@ NJGLOBAL = 25                   !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -55,8 +48,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -68,8 +61,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 100.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 100.0                  !   [k]
@@ -106,8 +99,8 @@ MAXIMUM_DEPTH = 600.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 4      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_BIHARMONIC = True      !   [Boolean] default = False
@@ -175,8 +168,8 @@ LIGHTEST_DENSITY = 1030.0       !   [kg m-3] default = 1031.0
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "circle_obcs" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -204,8 +197,7 @@ THICKNESS_CONFIG = "circle_obcs" !
 
 ! === module circle_obcs_initialization ===
 DISK_RADIUS = 24.0              !   [kilometers]
-                                ! The radius of the initially elevated disk in the
-                                ! circle_obcs test case.
+                                ! The radius of the initially elevated disk in the circle_obcs test case.
 
 ! === module MOM_diag_mediator ===
 
@@ -215,29 +207,25 @@ DISK_RADIUS = 24.0              !   [kilometers]
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
@@ -245,11 +233,10 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
@@ -261,81 +248,65 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 25.0                       !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 AH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -358,8 +329,8 @@ DTBT = -0.95                    !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.095445115010332E-05
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -368,18 +339,17 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.095445115010332E-05
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 1.0E-04                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -401,65 +371,56 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 0.5            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 120.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/double_gyre/MOM_parameter_doc.all
+++ b/ocean_only/double_gyre/MOM_parameter_doc.all
@@ -7,127 +7,108 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = False                 !   [Boolean] default = False
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = True                !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 2400.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 2400.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -135,16 +116,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 44                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -154,17 +133,15 @@ NJGLOBAL = 40                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 2                          !   [nondim]
                                 ! The number of model layers.
 
@@ -174,8 +151,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "spherical"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -222,19 +199,18 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
 EDGE_DEPTH = 100.0              !   [m] default = 100.0
                                 ! The depth at the edge of one of the named topographies.
 TOPOG_SLOPE_SCALE = 4.0E+05     !   [m] default = 4.0E+05
-                                ! The exponential decay scale used in defining some of
-                                ! the named topographies.
+                                ! The exponential decay scale used in defining some of the named topographies.
 MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -255,12 +231,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -268,15 +244,15 @@ PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -296,8 +272,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -334,12 +310,11 @@ GINT = 0.0098                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -365,8 +340,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -376,41 +351,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -426,108 +398,93 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -535,106 +492,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -642,50 +582,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -695,160 +629,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -858,53 +765,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -914,43 +812,39 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -970,99 +864,89 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = True          !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-06    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 DEPTH_LIST_FILE = "Depth_list.nc" ! default = "Depth_list.nc"
                                 ! The name of the depth list file.
 REQUIRE_DEPTH_LIST_CHECKSUMS = False !   [Boolean] default = True
-                                ! Require that matching checksums be in Depth_list.nc
-                                ! when reading the file.
+                                ! Require that matching checksums be in Depth_list.nc when reading the file.
 UPDATE_DEPTH_LIST_CHECKSUMS = True !   [Boolean] default = False
-                                ! Automatically update the Depth_list.nc file if the
-                                ! checksums are missing or do not match current values.
+                                ! Automatically update the Depth_list.nc file if the checksums are missing or do
+                                ! not match current values.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "2gyre"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1070,8 +954,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1079,48 +962,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 2400.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 10.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 110.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = -1.0                   !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1128,12 +1004,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/double_gyre/MOM_parameter_doc.debugging
+++ b/ocean_only/double_gyre/MOM_parameter_doc.debugging
@@ -7,45 +7,38 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/double_gyre/MOM_parameter_doc.layout
+++ b/ocean_only/double_gyre/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 4                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 4                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/double_gyre/MOM_parameter_doc.short
+++ b/ocean_only/double_gyre/MOM_parameter_doc.short
@@ -5,43 +5,35 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 ADIABATIC = True                !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 2400.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 2400.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 44                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -57,8 +49,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "spherical"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -102,8 +94,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 
 ! === module MOM_tracer_registry ===
 
@@ -140,8 +132,8 @@ GINT = 0.0098                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -175,47 +167,42 @@ THICKNESS_CONFIG = "uniform"    !
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_PressureForce ===
 
@@ -227,67 +214,55 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -309,55 +284,47 @@ DTBT = -0.9                     !   [s or nondim] default = -0.98
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 READ_DEPTH_LIST = True          !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-06    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 REQUIRE_DEPTH_LIST_CHECKSUMS = False !   [Boolean] default = True
-                                ! Require that matching checksums be in Depth_list.nc
-                                ! when reading the file.
+                                ! Require that matching checksums be in Depth_list.nc when reading the file.
 UPDATE_DEPTH_LIST_CHECKSUMS = True !   [Boolean] default = False
-                                ! Automatically update the Depth_list.nc file if the
-                                ! checksums are missing or do not match current values.
+                                ! Automatically update the Depth_list.nc file if the checksums are missing or do
+                                ! not match current values.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "2gyre"           !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 2400.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 10.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 110.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 60.0                       !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 120.0                !   [s] default = 60.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 21                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 4.0                    !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = -32.0                 !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.8                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,12 +363,11 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "external_gwave" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -437,8 +399,8 @@ SSH_ANOMALY_HEIGHT = 1.0        !   [m]
 SSH_ANOMALY_WIDTH = 5.0         !   [coordinate]
                                 ! The lateral width of the SSH anomaly.
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -461,11 +423,11 @@ T_REF = 5.0                     !   [degC]
 S_REF = 35.0                    !   [PSU] default = 35.0
                                 ! A reference salinity used in initialization.
 FIT_SALINITY = False            !   [Boolean] default = False
-                                ! If true, accept the prescribed temperature and fit the
-                                ! salinity; otherwise take salinity and fit temperature.
+                                ! If true, accept the prescribed temperature and fit the salinity; otherwise
+                                ! take salinity and fit temperature.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -475,41 +437,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -525,113 +484,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -639,106 +583,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.05E-14        !   [m] default = 1.05E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.05E-14    !   [m] default = 1.05E-14
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -746,50 +673,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -799,156 +720,132 @@ KH = 0.01                       !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = False         !   [Boolean] default = False
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -958,53 +855,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.01            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 1.0                 !   [m] default = 1.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1014,363 +902,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1387,91 +1232,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 1.0                  !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 600.0          !   [seconds] default = 8.64E+04
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [seconds] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1479,8 +1315,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1488,48 +1323,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 60.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1800.0                 !   [seconds]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 0.0                   !   [seconds] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1537,12 +1365,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/external_gwave/MOM_parameter_doc.debugging
+++ b/ocean_only/external_gwave/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/external_gwave/MOM_parameter_doc.layout
+++ b/ocean_only/external_gwave/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -5,32 +5,25 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 60.0                       !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 120.0                !   [s] default = 60.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -40,13 +33,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -54,10 +45,9 @@ NJGLOBAL = 4                    !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 21                         !   [nondim]
@@ -69,8 +59,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -82,13 +72,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 4.0                    !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = -32.0                 !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 TOPO_CONFIG = "flat"            !
@@ -123,8 +113,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -136,10 +126,9 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 
 ! === module MOM_restart ===
 
@@ -174,8 +163,8 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "external_gwave" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -207,8 +196,8 @@ SSH_ANOMALY_HEIGHT = 1.0        !   [m]
 SSH_ANOMALY_WIDTH = 5.0         !   [coordinate]
                                 ! The lateral width of the SSH anomaly.
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -237,29 +226,25 @@ T_REF = 5.0                     !   [degC]
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 
@@ -269,14 +254,13 @@ KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -289,65 +273,53 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 0.01                       !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DT_BT_FILTER = -0.01            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -370,27 +342,24 @@ DTBT = 20.0                     !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -417,61 +386,53 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 1.0                  !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 600.0          !   [seconds] default = 8.64E+04
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 60.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1800.0                 !   [seconds]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 800.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -256,19 +229,19 @@ DOME2D_SHELF_DEPTH = 0.2        !   [nondim] default = 0.2
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,11 +363,9 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1035.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -413,12 +374,11 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -444,8 +404,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -472,8 +432,8 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [1e-3] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -483,41 +443,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -533,113 +490,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -647,106 +589,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -754,50 +679,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -807,159 +726,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -969,53 +862,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1025,363 +909,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1398,91 +1239,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1490,8 +1322,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1499,48 +1330,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1548,12 +1372,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.layout
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -5,32 +5,25 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -38,13 +31,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -60,8 +51,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -73,8 +64,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 800.0                  !   [k]
@@ -110,14 +101,14 @@ TOPO_CONFIG = "DOME2D"          !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -129,17 +120,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -166,8 +154,7 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -176,8 +163,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -203,8 +190,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -237,62 +224,54 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -305,47 +284,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -355,20 +327,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -393,18 +362,16 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -422,11 +389,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -437,65 +403,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 800.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -256,19 +229,19 @@ DOME2D_SHELF_DEPTH = 0.2        !   [nondim] default = 0.2
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,21 +363,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -425,12 +385,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -441,14 +399,11 @@ INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -470,12 +425,10 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1034.0, 1034.025, 1034.0500000000002, 1034.0750000000003, 1034.1000000000004, 1034.1250000000005, 1034.1500000000005, 1034.1750000000006, 1034.2000000000007, 1034.2250000000008, 1034.250000000001, 1034.275000000001, 1034.300000000001, 1034.3250000000012, 1034.3500000000013, 1034.3750000000014, 1034.4000000000015, 1034.4250000000015, 1034.4500000000016, 1034.4750000000017, 1034.5000000000018, 1034.525000000002, 1034.550000000002, 1034.575000000002, 1034.6000000000022, 1034.6250000000023, 1034.6500000000024, 1034.6750000000025, 1034.7000000000025, 1034.7250000000026, 1034.7500000000027, 1034.7750000000028, 1034.800000000003, 1034.825000000003, 1034.850000000003, 1034.8750000000032, 1034.9000000000033, 1034.9250000000034, 1034.9500000000035, 1034.9750000000035, 1035.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "NONE" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -495,43 +448,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -542,12 +490,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -573,8 +520,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -601,8 +548,8 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [1e-3] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -612,45 +559,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -666,113 +610,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -780,106 +709,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -887,50 +799,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -940,159 +846,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1102,53 +982,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1158,363 +1029,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1531,91 +1359,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1623,8 +1442,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1632,48 +1450,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1681,12 +1492,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.layout
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -5,28 +5,23 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -34,13 +29,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -56,8 +49,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -69,8 +62,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 800.0                  !   [k]
@@ -106,14 +99,14 @@ TOPO_CONFIG = "DOME2D"          !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -125,17 +118,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -162,17 +152,14 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -181,12 +168,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -197,11 +182,9 @@ INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 !ALE_RESOLUTION = 40*0.025      !   [kg m^-3]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
@@ -211,10 +194,9 @@ BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
 !TARGET_DENSITIES = 1034.0, 1034.025, 1034.0500000000002, 1034.0750000000003, 1034.1000000000004, 1034.1250000000005, 1034.1500000000005, 1034.1750000000006, 1034.2000000000007, 1034.2250000000008, 1034.250000000001, 1034.275000000001, 1034.300000000001, 1034.3250000000012, 1034.3500000000013, 1034.3750000000014, 1034.4000000000015, 1034.4250000000015, 1034.4500000000016, 1034.4750000000017, 1034.5000000000018, 1034.525000000002, 1034.550000000002, 1034.575000000002, 1034.6000000000022, 1034.6250000000023, 1034.6500000000024, 1034.6750000000025, 1034.7000000000025, 1034.7250000000026, 1034.7500000000027, 1034.7750000000028, 1034.800000000003, 1034.825000000003, 1034.850000000003, 1034.8750000000032, 1034.9000000000033, 1034.9250000000034, 1034.9500000000035, 1034.9750000000035, 1035.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -226,8 +208,8 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -253,8 +235,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -287,62 +269,54 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -355,47 +329,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -405,20 +372,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -443,18 +407,16 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -472,11 +434,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -487,65 +448,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 800.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -256,19 +229,19 @@ DOME2D_SHELF_DEPTH = 0.2        !   [nondim] default = 0.2
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,21 +363,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1035.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -425,8 +385,7 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "Non-dimensional" ! default = "Non-dimensional"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -446,46 +405,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -496,12 +449,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -527,8 +479,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -555,8 +507,8 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [1e-3] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -566,45 +518,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -620,113 +569,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -734,106 +668,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -841,50 +758,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -894,159 +805,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1056,53 +941,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1112,363 +988,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1485,91 +1318,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1577,8 +1401,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1586,48 +1409,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1635,12 +1451,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.layout
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -5,28 +5,23 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -34,13 +29,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -56,8 +49,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -69,8 +62,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 800.0                  !   [k]
@@ -106,14 +99,14 @@ TOPO_CONFIG = "DOME2D"          !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -125,17 +118,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -162,14 +152,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -184,10 +172,9 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -199,8 +186,8 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -226,8 +213,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -260,62 +247,54 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -328,47 +307,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -378,20 +350,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -416,18 +385,16 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -445,11 +412,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -460,65 +426,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 800.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -256,19 +229,19 @@ DOME2D_SHELF_DEPTH = 0.2        !   [nondim] default = 0.2
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,21 +363,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1035.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -425,8 +385,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -446,46 +405,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -496,12 +449,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -527,8 +479,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -555,8 +507,8 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [1e-3] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -566,45 +518,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -620,113 +569,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -734,106 +668,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -841,50 +758,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -894,159 +805,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1056,53 +941,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1112,363 +988,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1485,91 +1318,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1577,8 +1401,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1586,48 +1409,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1635,12 +1451,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.layout
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -5,28 +5,23 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -34,13 +29,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -56,8 +49,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -69,8 +62,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 800.0                  !   [k]
@@ -106,14 +99,14 @@ TOPO_CONFIG = "DOME2D"          !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -125,17 +118,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -162,14 +152,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -184,10 +172,9 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -199,8 +186,8 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "DOME2D"     !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -226,8 +213,8 @@ THICKNESS_CONFIG = "DOME2D"     !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "DOME2D"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -260,62 +247,54 @@ S_RANGE = 1.0                   !   [1e-3] default = 2.0
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -328,47 +307,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -378,20 +350,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 20.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -416,18 +385,16 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -445,11 +412,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -460,65 +426,56 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 12.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 20.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 45.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 45.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -2.1          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 50                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -294,54 +266,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -361,8 +328,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -372,27 +339,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -418,16 +383,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -438,12 +401,10 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -454,14 +415,11 @@ INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = False  !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_50.nc,sigma2,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -483,12 +441,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_50.nc,sigma2,dz" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1010.0, 1016.1289, 1020.843, 1024.821, 1027.0275, 1028.2911, 1029.2795, 1030.1194, 1030.8626, 1031.5364, 1032.1572, 1032.7358, 1033.2798, 1033.7948, 1034.2519, 1034.5828, 1034.8508, 1035.0821, 1035.2886, 1035.4769, 1035.6511, 1035.814, 1035.9675, 1036.1107, 1036.2411, 1036.3615, 1036.4739, 1036.5797, 1036.68, 1036.7755, 1036.8526, 1036.9024, 1036.9418, 1036.9754, 1037.0052, 1037.0323, 1037.0574, 1037.082, 1037.1066, 1037.1312, 1037.1558, 1037.1804, 1037.206, 1037.2337, 1037.2642, 1037.2986, 1037.3389, 1037.3901, 1037.475, 1037.7204, 1038.0 !   [m]
                                 ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,12000,1.0,.125" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -510,43 +466,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 8.64E+04    !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -557,48 +508,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = True !   [Boolean] default = True
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -608,45 +551,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -662,53 +602,49 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 0.0                !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -716,314 +652,273 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -1031,107 +926,98 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the S2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the S2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_N2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the N2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the N2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_O1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the O1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the O1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_P1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the P1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the P1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_Q1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the Q1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the Q1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MF = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MF
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MF frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MM = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MM
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MM frequency. This is only used
+                                ! if TIDES is true.
 TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
-                                ! If true, read the tidal self-attraction and loading
-                                ! from input files, specified by TIDAL_INPUT_FILE.
-                                ! This is only used if TIDES is true.
+                                ! If true, read the tidal self-attraction and loading from input files,
+                                ! specified by TIDAL_INPUT_FILE. This is only used if TIDES is true.
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
-                                ! If true, use the SAL from the previous iteration of the
-                                ! tides to facilitate convergent iteration.
-                                ! This is only used if TIDES is true.
+                                ! If true, use the SAL from the previous iteration of the tides to facilitate
+                                ! convergent iteration. This is only used if TIDES is true.
 TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
-                                ! If true and TIDES is true, use the scalar approximation
-                                ! when calculating self-attraction and loading.
+                                ! If true and TIDES is true, use the scalar approximation when calculating
+                                ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 TIDE_M2_FREQ = 1.405189E-04     !   [s-1] default = 1.405189E-04
-                                ! Frequency of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Frequency of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_AMP = 0.242334          !   [m] default = 0.242334
-                                ! Amplitude of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Amplitude of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_PHASE_T0 = 0.0          !   [radians] default = 0.0
-                                ! Phase of the M2 tidal constituent at time 0.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Phase of the M2 tidal constituent at time 0. This is only used if TIDES and
+                                ! TIDE_M2 are true.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1141,194 +1027,162 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1338,53 +1192,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -1394,465 +1239,412 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 1.0         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
-FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
                                 ! streamfunction formulation.
+FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
                                 ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary
-                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
+                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 0.0          !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 0.0        !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_DENSITY_DIFF = 0.03         !   [kg/m3] default = 0.03
-                                ! Density difference used to detect the mixed-layer
-                                ! depth used for the mixed-layer eddy parameterization
-                                ! by Fox-Kemper et al. (2010)
+                                ! Density difference used to detect the mixed-layer depth used for the
+                                ! mixed-layer eddy parameterization by Fox-Kemper et al. (2010)
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1861,150 +1653,134 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -2021,199 +1797,180 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 LONGWAVE_FORCING_VAR = "LW"     ! default = "LW"
                                 ! The variable with the longwave forcing field.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 SHORTWAVE_FORCING_VAR = "SW"    ! default = "SW"
                                 ! The variable with the shortwave forcing field.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 EVAP_FORCING_VAR = "evap"       ! default = "evap"
                                 ! The variable with the evaporative moisture flux.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 LATENT_FORCING_VAR = "latent"   ! default = "latent"
                                 ! The variable with the latent heat flux.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 SENSIBLE_FORCING_VAR = "sensible" ! default = "sensible"
                                 ! The variable with the sensible heat flux.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 RAIN_FORCING_VAR = "liq_precip" ! default = "liq_precip"
                                 ! The variable with the liquid precipitation flux.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 SNOW_FORCING_VAR = "froz_precip" ! default = "froz_precip"
                                 ! The variable with the frozen precipitation flux.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 LIQ_RUNOFF_FORCING_VAR = "liq_runoff" ! default = "liq_runoff"
                                 ! The variable with the liquid runoff flux.
 FROZ_RUNOFF_FORCING_VAR = "froz_runoff" ! default = "froz_runoff"
                                 ! The variable with the frozen runoff flux.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 SST_RESTORE_VAR = "SST"         ! default = "SST"
                                 ! The variable with the SST toward which to restore.
 SSS_RESTORE_VAR = "SSS"         ! default = "SSS"
                                 ! The variable with the SSS toward which to restore.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 WINDSTRESS_SCALE = 1.0          !   [nondim] default = 1.0
                                 ! A value by which the wind stresses in WIND_FILE are rescaled.
 USTAR_FORCING_VAR = ""          !   [nondim] default = ""
-                                ! The name of the friction velocity variable in WIND_FILE
-                                ! or blank to get ustar from the wind stresses plus the
-                                ! gustiness.
+                                ! The name of the friction velocity variable in WIND_FILE or blank to get ustar
+                                ! from the wind stresses plus the gustiness.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_T = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface temperature
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface temperature flux to the
+                                ! relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_S = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface salinity
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface salinity flux to the relative
+                                ! surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -2221,48 +1978,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -2270,12 +2020,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.layout
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 8                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 8                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 8, 8                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -5,75 +5,62 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -89,8 +76,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -127,14 +114,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -147,8 +134,8 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -184,9 +171,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -195,8 +181,7 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "HYBRID:hycom1_50.nc,sigma2,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -229,125 +214,108 @@ MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,12000,1.0,.125" ! default = "NONE"
 !MAXIMUM_INT_DEPTHS = 0.0, 5.0, 19.625, 43.75, 77.5, 120.875, 173.875, 236.375, 308.5, 390.25, 481.625, 582.5, 693.0, 813.125, 942.875, 1082.125, 1231.0, 1389.5, 1557.5, 1735.125, 1922.375, 2119.25, 2325.625, 2541.625, 2767.25, 3002.5, 3247.25, 3501.625, 3765.625, 4039.25, 4322.375, 4615.125, 4917.5, 5229.5, 5551.0, 5882.125, 6222.875, 6573.125, 6933.0, 7302.5, 7681.625, 8070.25, 8468.5, 8876.375, 9293.875, 9720.875, 1.01575E+04, 1.060375E+04, 1.1059625E+04, 1.1525E+04, 1.2E+04 !   [m]
                                 ! The list of maximum depths for each interface.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 8.64E+04    !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 
 ! === module MOM_diag_mediator ===
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 
@@ -355,105 +323,88 @@ TIDES = True                    !   [Boolean] default = False
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -461,44 +412,38 @@ KHTH = 600.0                    !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
-                                ! streamfunction formulation.
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -507,87 +452,79 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -600,23 +537,21 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -642,116 +577,101 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -7,165 +7,140 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 20.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 45.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 45.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -2.1          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -173,16 +148,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -192,17 +165,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -212,8 +183,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -222,8 +193,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -259,19 +230,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -292,54 +263,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -359,8 +325,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -370,27 +336,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -416,65 +380,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "Layer_coord.nc"   !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -484,41 +437,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -534,53 +484,49 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 0.0                !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -588,311 +534,270 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -900,107 +805,98 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the S2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the S2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_N2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the N2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the N2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_O1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the O1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the O1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_P1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the P1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the P1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_Q1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the Q1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the Q1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MF = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MF
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MF frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MM = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MM
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MM frequency. This is only used
+                                ! if TIDES is true.
 TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
-                                ! If true, read the tidal self-attraction and loading
-                                ! from input files, specified by TIDAL_INPUT_FILE.
-                                ! This is only used if TIDES is true.
+                                ! If true, read the tidal self-attraction and loading from input files,
+                                ! specified by TIDAL_INPUT_FILE. This is only used if TIDES is true.
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
-                                ! If true, use the SAL from the previous iteration of the
-                                ! tides to facilitate convergent iteration.
-                                ! This is only used if TIDES is true.
+                                ! If true, use the SAL from the previous iteration of the tides to facilitate
+                                ! convergent iteration. This is only used if TIDES is true.
 TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
-                                ! If true and TIDES is true, use the scalar approximation
-                                ! when calculating self-attraction and loading.
+                                ! If true and TIDES is true, use the scalar approximation when calculating
+                                ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 TIDE_M2_FREQ = 1.405189E-04     !   [s-1] default = 1.405189E-04
-                                ! Frequency of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Frequency of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_AMP = 0.242334          !   [m] default = 0.242334
-                                ! Amplitude of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Amplitude of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_PHASE_T0 = 0.0          !   [radians] default = 0.0
-                                ! Phase of the M2 tidal constituent at time 0.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Phase of the M2 tidal constituent at time 0. This is only used if TIDES and
+                                ! TIDE_M2 are true.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1010,186 +906,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1199,53 +1065,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -1255,562 +1112,494 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 1.0         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
-FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
                                 ! streamfunction formulation.
+FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
                                 ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary
-                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
+                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -1827,189 +1616,172 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 LONGWAVE_FORCING_VAR = "LW"     ! default = "LW"
                                 ! The variable with the longwave forcing field.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 SHORTWAVE_FORCING_VAR = "SW"    ! default = "SW"
                                 ! The variable with the shortwave forcing field.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 EVAP_FORCING_VAR = "evap"       ! default = "evap"
                                 ! The variable with the evaporative moisture flux.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 LATENT_FORCING_VAR = "latent"   ! default = "latent"
                                 ! The variable with the latent heat flux.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 SENSIBLE_FORCING_VAR = "sensible" ! default = "sensible"
                                 ! The variable with the sensible heat flux.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 RAIN_FORCING_VAR = "liq_precip" ! default = "liq_precip"
                                 ! The variable with the liquid precipitation flux.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 SNOW_FORCING_VAR = "froz_precip" ! default = "froz_precip"
                                 ! The variable with the frozen precipitation flux.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 LIQ_RUNOFF_FORCING_VAR = "liq_runoff" ! default = "liq_runoff"
                                 ! The variable with the liquid runoff flux.
 FROZ_RUNOFF_FORCING_VAR = "froz_runoff" ! default = "froz_runoff"
                                 ! The variable with the frozen runoff flux.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 SST_RESTORE_VAR = "SST"         ! default = "SST"
                                 ! The variable with the SST toward which to restore.
 SSS_RESTORE_VAR = "SSS"         ! default = "SSS"
                                 ! The variable with the SSS toward which to restore.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 WINDSTRESS_SCALE = 1.0          !   [nondim] default = 1.0
                                 ! A value by which the wind stresses in WIND_FILE are rescaled.
 USTAR_FORCING_VAR = ""          !   [nondim] default = ""
-                                ! The name of the friction velocity variable in WIND_FILE
-                                ! or blank to get ustar from the wind stresses plus the
-                                ! gustiness.
+                                ! The name of the friction velocity variable in WIND_FILE or blank to get ustar
+                                ! from the wind stresses plus the gustiness.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_T = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface temperature
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface temperature flux to the
+                                ! relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_S = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface salinity
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface salinity flux to the relative
+                                ! surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -2017,48 +1789,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -2066,12 +1831,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.layout
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 8                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 8                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 8, 8                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -5,72 +5,59 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -86,8 +73,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -124,14 +111,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -144,8 +131,8 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -186,95 +173,79 @@ COORD_FILE = "Layer_coord.nc"   !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 
@@ -282,34 +253,30 @@ TIDES = True                    !   [Boolean] default = False
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 
@@ -319,57 +286,46 @@ TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -377,37 +333,32 @@ KHTH = 600.0                    !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
-                                ! streamfunction formulation.
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -419,82 +370,75 @@ Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -507,51 +451,45 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -575,116 +513,101 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -7,167 +7,143 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 BAD_VAL_SSH_MAX = 20.0          !   [m] default = 20.0
-                                ! The value of SSH above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSH above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SSS_MAX = 45.0          !   [PPT] default = 45.0
-                                ! The value of SSS above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SSS above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MAX = 45.0          !   [deg C] default = 45.0
-                                ! The value of SST above which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST above which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_SST_MIN = -2.1          !   [deg C] default = -2.1
-                                ! The value of SST below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of SST below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
-                                ! The value of column thickness below which a bad value message is
-                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+                                ! The value of column thickness below which a bad value message is triggered, if
+                                ! CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -175,16 +151,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -194,17 +168,15 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 50                         !   [nondim]
                                 ! The number of model layers.
 
@@ -214,8 +186,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -224,8 +196,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -261,19 +233,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -294,54 +266,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -361,8 +328,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -372,27 +339,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -418,16 +383,14 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -438,8 +401,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -459,46 +421,40 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -509,48 +465,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -560,45 +508,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -614,53 +559,49 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
-                                ! The ratio of the bottom eddy velocity to the column mean
-                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
-                                ! to account for the surface intensification of MEKE.
+                                ! The ratio of the bottom eddy velocity to the column mean eddy velocity, i.e.
+                                ! sqrt(2*MEKE). This should be less than 1 to account for the surface
+                                ! intensification of MEKE.
 MEKE_CB = 25.0                  !   [nondim] default = 25.0
-                                ! A coefficient in the expression for the ratio of bottom projected
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of bottom projected eddy energy
+                                ! and mean column energy (see Jansen et al. 2015).
 MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
                                 ! The minimum allowed value of gamma_b^2.
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
-                                ! A coefficient in the expression for the ratio of barotropic
-                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+                                ! A coefficient in the expression for the ratio of barotropic eddy energy and
+                                ! mean column energy (see Jansen et al. 2015).
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of mean energy into
-                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
-                                ! is not used or calculated.
+                                ! The efficiency of the conversion of mean energy into MEKE.  If MEKE_FRCOEFF is
+                                ! negative, this conversion is not used or calculated.
 MEKE_BGSRC = 0.0                !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
-                                ! A background lateral diffusivity of MEKE.
-                                ! Use a negative value to not apply lateral diffusion to MEKE.
+                                ! A background lateral diffusivity of MEKE. Use a negative value to not apply
+                                ! lateral diffusion to MEKE.
 MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
-                                ! A lateral bi-harmonic diffusivity of MEKE.
-                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+                                ! A lateral bi-harmonic diffusivity of MEKE. Use a negative value to not apply
+                                ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
-                                ! A scaling factor in the expression for eddy diffusivity
-                                ! which is otherwise proportional to the MEKE velocity-
-                                ! scale times an eddy mixing-length. This factor
-                                ! must be >0 for MEKE to contribute to the thickness/
-                                ! and tracer diffusivity in the rest of the model.
+                                ! A scaling factor in the expression for eddy diffusivity which is otherwise
+                                ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
+                                ! factor must be >0 for MEKE to contribute to the thickness/ and tracer
+                                ! diffusivity in the rest of the model.
 MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
-                                ! The background velocity that is combined with MEKE to
-                                ! calculate the bottom drag.
+                                ! The background velocity that is combined with MEKE to calculate the bottom
+                                ! drag.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
-                                ! If true, use the vertvisc_type to calculate the bottom
-                                ! drag acting on MEKE.
+                                ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
 MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
 MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
@@ -668,314 +609,273 @@ MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
 MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use the old formula for length scale which is
-                                ! a function of grid spacing and deformation radius.
+                                ! If true, use the old formula for length scale which is a function of grid
+                                ! spacing and deformation radius.
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
-                                ! If true, use a strict minimum of provided length scales
-                                ! rather than harmonic mean.
+                                ! If true, use a strict minimum of provided length scales rather than harmonic
+                                ! mean.
 MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
-                                ! If true, the length scale used by MEKE is the minimum of
-                                ! the deformation radius or grid-spacing. Only used if
-                                ! MEKE_OLD_LSCALE=True
+                                ! If true, the length scale used by MEKE is the minimum of the deformation
+                                ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
 MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! If non-zero, is the scaling coefficient in the expression for
-                                ! viscosity used to parameterize lateral momentum mixing by
-                                ! unresolved eddies represented by MEKE. Can be negative to
-                                ! represent backscatter from the unresolved eddies.
+                                ! If non-zero, is the scaling coefficient in the expression for viscosity used
+                                ! to parameterize lateral momentum mixing by unresolved eddies represented by
+                                ! MEKE. Can be negative to represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
-                                ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a fixed length contribution to the expression for mixing
+                                ! length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the deformation scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Rhines scale in the expression for
+                                ! mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
-                                ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the Eady length scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the frictional arrest scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
-                                ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusivity.
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale in the
+                                ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
-                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
-                                ! is used as an initial condition for EKE.
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution is
+                                ! used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number
                                 ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source.
+                                ! The power in the Rossby number function for scaling the biharmonic frictional
+                                ! energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
-                                ! A scale factor to determine how much topographic beta is weighed in
-                                ! computing beta in the expression of Rhines scale. Use 1 if full
-                                ! topographic beta effect is considered; use 0 if it's completely ignored.
+                                ! A scale factor to determine how much topographic beta is weighed in computing
+                                ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
+                                ! is considered; use 0 if it's completely ignored.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 VARMIX_KTOP = 2                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -983,107 +883,98 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the S2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the S2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_N2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the N2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the N2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_O1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the O1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the O1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_P1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the P1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the P1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_Q1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the Q1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the Q1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MF = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MF
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MF frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MM = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MM
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MM frequency. This is only used
+                                ! if TIDES is true.
 TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
-                                ! If true, read the tidal self-attraction and loading
-                                ! from input files, specified by TIDAL_INPUT_FILE.
-                                ! This is only used if TIDES is true.
+                                ! If true, read the tidal self-attraction and loading from input files,
+                                ! specified by TIDAL_INPUT_FILE. This is only used if TIDES is true.
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
-                                ! If true, use the SAL from the previous iteration of the
-                                ! tides to facilitate convergent iteration.
-                                ! This is only used if TIDES is true.
+                                ! If true, use the SAL from the previous iteration of the tides to facilitate
+                                ! convergent iteration. This is only used if TIDES is true.
 TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
-                                ! If true and TIDES is true, use the scalar approximation
-                                ! when calculating self-attraction and loading.
+                                ! If true and TIDES is true, use the scalar approximation when calculating
+                                ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 TIDE_M2_FREQ = 1.405189E-04     !   [s-1] default = 1.405189E-04
-                                ! Frequency of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Frequency of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_AMP = 0.242334          !   [m] default = 0.242334
-                                ! Amplitude of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Amplitude of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_PHASE_T0 = 0.0          !   [radians] default = 0.0
-                                ! Phase of the M2 tidal constituent at time 0.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Phase of the M2 tidal constituent at time 0. This is only used if TIDES and
+                                ! TIDE_M2 are true.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -1093,194 +984,162 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1290,53 +1149,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -1346,465 +1196,412 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_FILTER_SCALE = 1.0         !   [not defined] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the
-                                ! Ferrari et al., 2010, streamfunction formulation.
-FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
                                 ! streamfunction formulation.
+FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
                                 ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary
-                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
+                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 0.0          !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 0.0        !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_DENSITY_DIFF = 0.03         !   [kg/m3] default = 0.03
-                                ! Density difference used to detect the mixed-layer
-                                ! depth used for the mixed-layer eddy parameterization
-                                ! by Fox-Kemper et al. (2010)
+                                ! Density difference used to detect the mixed-layer depth used for the
+                                ! mixed-layer eddy parameterization by Fox-Kemper et al. (2010)
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
-                                ! If true, use the maximum of Omega and N for the TKE to diffusion
-                                ! calculation. Otherwise, N is N.
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion calculation.
+                                ! Otherwise, N is N.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1813,150 +1610,134 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 TKE_DECAY = 2.5                 !   [nondim] default = 2.5
-                                ! TKE_DECAY relates the vertical rate of decay of the
-                                ! TKE available for mechanical entrainment to the natural
-                                ! Ekman depth.
+                                ! TKE_DECAY relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth.
 ML_OMEGA_FRAC = 0.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
@@ -1973,199 +1754,180 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 LONGWAVE_FORCING_VAR = "LW"     ! default = "LW"
                                 ! The variable with the longwave forcing field.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 SHORTWAVE_FORCING_VAR = "SW"    ! default = "SW"
                                 ! The variable with the shortwave forcing field.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 EVAP_FORCING_VAR = "evap"       ! default = "evap"
                                 ! The variable with the evaporative moisture flux.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 LATENT_FORCING_VAR = "latent"   ! default = "latent"
                                 ! The variable with the latent heat flux.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 SENSIBLE_FORCING_VAR = "sensible" ! default = "sensible"
                                 ! The variable with the sensible heat flux.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 RAIN_FORCING_VAR = "liq_precip" ! default = "liq_precip"
                                 ! The variable with the liquid precipitation flux.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 SNOW_FORCING_VAR = "froz_precip" ! default = "froz_precip"
                                 ! The variable with the frozen precipitation flux.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 LIQ_RUNOFF_FORCING_VAR = "liq_runoff" ! default = "liq_runoff"
                                 ! The variable with the liquid runoff flux.
 FROZ_RUNOFF_FORCING_VAR = "froz_runoff" ! default = "froz_runoff"
                                 ! The variable with the frozen runoff flux.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 SST_RESTORE_VAR = "SST"         ! default = "SST"
                                 ! The variable with the SST toward which to restore.
 SSS_RESTORE_VAR = "SSS"         ! default = "SSS"
                                 ! The variable with the SSS toward which to restore.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 WINDSTRESS_SCALE = 1.0          !   [nondim] default = 1.0
                                 ! A value by which the wind stresses in WIND_FILE are rescaled.
 USTAR_FORCING_VAR = ""          !   [nondim] default = ""
-                                ! The name of the friction velocity variable in WIND_FILE
-                                ! or blank to get ustar from the wind stresses plus the
-                                ! gustiness.
+                                ! The name of the friction velocity variable in WIND_FILE or blank to get ustar
+                                ! from the wind stresses plus the gustiness.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_T = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface temperature
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface temperature flux to the
+                                ! relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_S = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface salinity
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface salinity flux to the relative
+                                ! surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -2173,48 +1935,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -2222,12 +1977,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.layout
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 8                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 8                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 8, 8                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -5,75 +5,62 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -89,8 +76,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -127,14 +114,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -147,8 +134,8 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -184,9 +171,8 @@ COORD_CONFIG = "file"           !
 COORD_FILE = "Layer_coord50.nc" !
                                 ! The file from which the coordinate densities are read.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -195,8 +181,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -216,10 +201,9 @@ ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -231,22 +215,18 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
@@ -254,74 +234,63 @@ Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
-                                ! The efficiency of the conversion of potential energy
-                                ! into MEKE by the thickness mixing parameterization.
-                                ! If MEKE_GMCOEFF is negative, this conversion is not
-                                ! used or calculated.
+                                ! The efficiency of the conversion of potential energy into MEKE by the
+                                ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
+                                ! conversion is not used or calculated.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 USE_STORED_SLOPES = True        !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 
@@ -329,105 +298,88 @@ TIDES = True                    !   [Boolean] default = False
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
@@ -435,44 +387,38 @@ KHTH = 600.0                    !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010,
-                                ! streamfunction formulation.
+                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
+                                ! formulation.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -481,87 +427,79 @@ ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -574,23 +512,21 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -616,116 +552,101 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 250.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 250.0                !   [s] default = 250.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 21                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 4.0                    !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = -32.0                 !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.8                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -400,12 +363,11 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "lock_exchange" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -433,15 +395,15 @@ THICKNESS_CONFIG = "lock_exchange" !
 
 ! === module lock_exchange_initialize_thickness ===
 FRONT_DISPLACEMENT = 20.0       !   [m]
-                                ! The vertical displacement of interfaces across the front.
-                                ! A value larger in magnitude that MAX_DEPTH is truncated,
+                                ! The vertical displacement of interfaces across the front. A value larger in
+                                ! magnitude that MAX_DEPTH is truncated,
 THERMOCLINE_THICKNESS = 0.0     !   [m] default = 0.0
-                                ! The thickness of the thermocline in the lock exchange
-                                ! experiment.  A value of zero creates a two layer system
-                                ! with vanished layers in between the two inflated layers.
+                                ! The thickness of the thermocline in the lock exchange experiment.  A value of
+                                ! zero creates a two layer system with vanished layers in between the two
+                                ! inflated layers.
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -464,11 +426,11 @@ T_REF = 5.0                     !   [degC]
 S_REF = 35.0                    !   [PSU] default = 35.0
                                 ! A reference salinity used in initialization.
 FIT_SALINITY = False            !   [Boolean] default = False
-                                ! If true, accept the prescribed temperature and fit the
-                                ! salinity; otherwise take salinity and fit temperature.
+                                ! If true, accept the prescribed temperature and fit the salinity; otherwise
+                                ! take salinity and fit temperature.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -478,41 +440,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -528,113 +487,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -642,106 +586,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.05E-14        !   [m] default = 1.05E-14
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.05E-14    !   [m] default = 1.05E-14
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -749,50 +676,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -802,156 +723,132 @@ KH = 0.01                       !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = False         !   [Boolean] default = False
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -961,53 +858,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 1.0                 !   [m] default = 1.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 25.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1017,363 +905,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1390,91 +1235,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 1.0                  !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0E+04        !   [seconds] default = 8.64E+04
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [seconds] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1482,8 +1318,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1491,48 +1326,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 5000.0             !   [s] default = 250.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 6.5E+04                !   [seconds]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 0.0                   !   [seconds] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1540,12 +1368,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/lock_exchange/MOM_parameter_doc.debugging
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/lock_exchange/MOM_parameter_doc.layout
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -5,25 +5,20 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 250.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -33,13 +28,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 128                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -47,10 +40,9 @@ NJGLOBAL = 4                    !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 21                         !   [nondim]
@@ -62,8 +54,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -75,13 +67,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 4.0                    !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = -32.0                 !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 64.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 TOPO_CONFIG = "flat"            !
@@ -116,8 +108,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -129,10 +121,9 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 
 ! === module MOM_restart ===
 
@@ -167,8 +158,8 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "lock_exchange" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -196,11 +187,11 @@ THICKNESS_CONFIG = "lock_exchange" !
 
 ! === module lock_exchange_initialize_thickness ===
 FRONT_DISPLACEMENT = 20.0       !   [m]
-                                ! The vertical displacement of interfaces across the front.
-                                ! A value larger in magnitude that MAX_DEPTH is truncated,
+                                ! The vertical displacement of interfaces across the front. A value larger in
+                                ! magnitude that MAX_DEPTH is truncated,
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -229,29 +220,25 @@ T_REF = 5.0                     !   [degC]
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 
@@ -261,14 +248,13 @@ KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -281,60 +267,49 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 0.01                       !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 25.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -357,27 +332,24 @@ DTBT = 25.0                     !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -404,61 +376,53 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 1.0                  !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0E+04        !   [seconds] default = 8.64E+04
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 5000.0             !   [s] default = 250.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 6.5E+04                !   [seconds]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 3600.0      !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3991.86795711963          !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 80                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 400.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 40.0                   !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.8                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1000.0       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,8 +374,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -435,46 +394,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -485,12 +438,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "rossby_front" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -520,8 +472,8 @@ THICKNESS_CONFIG = "rossby_front" !
 T_RANGE = 5.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 TS_CONFIG = "rossby_front"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +496,8 @@ S_REF = 34.0                    !   [1e-3]
 T_REF = 20.0                    !   [C]
                                 ! Reference temperature
 VELOCITY_CONFIG = "rossby_front" ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +507,42 @@ VELOCITY_CONFIG = "rossby_front" ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +558,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 1.0E-04           !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -723,106 +657,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -830,50 +747,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -883,159 +794,133 @@ KH = 1.0E+04                    !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.001              !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 0.001             !   [m] default = 0.001
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1045,53 +930,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.98                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -1101,408 +977,360 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
-                                ! of the MLE restratification parameterization.
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application of the MLE
+                                ! restratification parameterization.
 MLE_FRONT_LENGTH = 0.0          !   [m] default = 0.0
-                                ! If non-zero, is the frontal-length scale used to calculate the
-                                ! upscaling of buoyancy gradients that is otherwise represented
-                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
-                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+                                ! If non-zero, is the frontal-length scale used to calculate the upscaling of
+                                ! buoyancy gradients that is otherwise represented by the parameter
+                                ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
+                                ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
-                                ! If true, the MLE parameterization will use the mixed-layer
-                                ! depth provided by the active PBL parameterization. If false,
-                                ! MLE will estimate a MLD based on a density difference with the
-                                ! surface using the parameter MLE_DENSITY_DIFF.
+                                ! If true, the MLE parameterization will use the mixed-layer depth provided by
+                                ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
+                                ! density difference with the surface using the parameter MLE_DENSITY_DIFF.
 MLE_MLD_DECAY_TIME = 0.0        !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the mixed-layer
-                                ! depth used in the MLE restratification parameterization. When
-                                ! the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the mixed-layer depth used
+                                ! in the MLE restratification parameterization. When the MLD deepens below the
+                                ! current running-mean the running-mean is instantaneously set to the current
+                                ! MLD.
 MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
-                                ! The time-scale for a running-mean filter applied to the filtered
-                                ! mixed-layer depth used in a second MLE restratification parameterization.
-                                ! When the MLD deepens below the current running-mean the running-mean
-                                ! is instantaneously set to the current MLD.
+                                ! The time-scale for a running-mean filter applied to the filtered mixed-layer
+                                ! depth used in a second MLE restratification parameterization. When the MLD
+                                ! deepens below the current running-mean the running-mean is instantaneously set
+                                ! to the current MLD.
 MLE_DENSITY_DIFF = 0.03         !   [kg/m3] default = 0.03
-                                ! Density difference used to detect the mixed-layer
-                                ! depth used for the mixed-layer eddy parameterization
-                                ! by Fox-Kemper et al. (2010)
+                                ! Density difference used to detect the mixed-layer depth used for the
+                                ! mixed-layer eddy parameterization by Fox-Kemper et al. (2010)
 MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
-                                ! Fraction by which to extend the mixed-layer restratification
-                                ! depth used for a smoother stream function at the base of
-                                ! the mixed-layer.
+                                ! Fraction by which to extend the mixed-layer restratification depth used for a
+                                ! smoother stream function at the base of the mixed-layer.
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
-                                ! A scaling coefficient for stretching/shrinking the MLD
-                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+                                ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
+                                ! This simply multiplies MLD wherever used.
 MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
                                 ! If true, do not account for MLD mismatch to interface positions.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1519,91 +1347,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [hours] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1611,8 +1430,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1620,48 +1438,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 10.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1669,12 +1480,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.debugging
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.layout
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -5,28 +5,24 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 NIGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 80                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -34,10 +30,9 @@ NJGLOBAL = 80                   !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 NK = 40                         !   [nondim]
                                 ! The number of model layers.
 
@@ -47,8 +42,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -60,8 +55,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 400.0                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 40.0                   !   [k]
@@ -98,8 +93,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -107,17 +102,15 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 
 ! === module MOM_restart ===
 
@@ -143,12 +136,10 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -163,10 +154,9 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -178,8 +168,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "rossby_front" !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -209,8 +199,8 @@ THICKNESS_CONFIG = "rossby_front" !
 T_RANGE = 5.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 TS_CONFIG = "rossby_front"      !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -233,8 +223,8 @@ S_REF = 34.0                    !   [1e-3]
 T_REF = 20.0                    !   [C]
                                 ! Reference temperature
 VELOCITY_CONFIG = "rossby_front" ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -252,62 +242,54 @@ VELOCITY_CONFIG = "rossby_front" ! default = "zero"
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 1.0E-04           !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 2.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -320,38 +302,33 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0E+04                    !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 0.001              !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -361,12 +338,11 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
@@ -374,19 +350,16 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 
@@ -405,18 +378,16 @@ FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -434,11 +405,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -449,59 +419,51 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 TIMEUNIT = 3600.0               !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 10.0                   !   [hours]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 240.0                 !   [hours] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -7,150 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.01             !   [PPT] default = 0.01
-                                ! The minimum value of salinity when BOUND_SALINITY=True.
-                                ! The default is 0.01 for backward compatibility but ideally
-                                ! should be 0.
+                                ! The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+                                ! for backward compatibility but ideally should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -158,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -177,17 +150,16 @@ NJGLOBAL = 210                  !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = False              !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_KG_M2 = 1.0                !   [kg m-2 H-1] default = 1.0
-                                ! A constant that translates thicknesses from the model's
-                                ! internal units of thickness to kg m-2.
+                                ! A constant that translates thicknesses from the model's internal units of
+                                ! thickness to kg m-2.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -197,8 +169,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -207,8 +179,8 @@ GRID_CONFIG = "mosaic"          !
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees.
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -244,19 +216,19 @@ TOPO_EDITS_FILE = ""            ! default = ""
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -277,54 +249,49 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -344,8 +311,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -355,27 +322,25 @@ USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age
-                                ! in the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
+                                ! ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
-                                ! If true, use an ideal vintage tracer that is set to an
-                                ! exponentially increasing value in the mixed layer and
-                                ! is conserved thereafter.
+                                ! If true, use an ideal vintage tracer that is set to an exponentially
+                                ! increasing value in the mixed layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
-                                ! If true, use an ideal age tracer that is everywhere 0
-                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
-                                ! the standard ideal age tracer - i.e. is set to 0 age in
-                                ! the mixed layer and ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is everywhere 0 before
+                                ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
+                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! interior.
 AGE_IC_FILE = ""                ! default = ""
-                                ! The file in which the age-tracer initial values can be
-                                ! found, or an empty string for internal initialization.
+                                ! The file in which the age-tracer initial values can be found, or an empty
+                                ! string for internal initialization.
 AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
                                 ! If true, AGE_IC_FILE is in depth space, not layer space
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "file"           !
@@ -401,20 +366,18 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -442,12 +405,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -474,8 +436,8 @@ SALT_IC_VAR = "SALT"            ! default = "SALT"
 SALT_FILE = "GOLD_IC.2010.11.15.nc" ! default = "GOLD_IC.2010.11.15.nc"
                                 ! The initial condition file for salinity.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -485,41 +447,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = True  !   [Boolean] default = True
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -535,285 +494,242 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
-                                ! If non-zero, is an upper bound on slopes used in the
-                                ! Visbeck formula for diffusivity. This does not affect the
-                                ! isopycnal slope calculation used within thickness diffusion.
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient that determines how KhTh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
 KH_RES_FN_POWER = 2             !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used.
 VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
-                                ! A coefficient that determines how Kh is scaled away if
-                                ! RESOLN_SCALED_... is true, as
-                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+                                ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+                                ! function affects lateral viscosity, Kh, and not KhTh.
 VISC_RES_FN_POWER = 2           !   [nondim] default = 2
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
+                                ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+                                ! used, although even integers are more efficient to calculate.  Setting this
+                                ! greater than 100 results in a step-function being used. This function affects
+                                ! lateral viscosity, Kh, and not KhTh.
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the
-                                ! velocity points from the thickness points; otherwise
-                                ! interpolate the wave speed and calculate the resolution
-                                ! function independently at each point.
+                                ! If true, interpolate the resolution function to the velocity points from the
+                                ! thickness points; otherwise interpolate the wave speed and calculate the
+                                ! resolution function independently at each point.
 USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
-                                ! If true, then retain a legacy bug in the calculation of weights
-                                ! applied to isoneutral slopes. There was an erroneous k-indexing
-                                ! for layer thicknesses. In addition, masking at coastlines was not
-                                ! used which introduced potential restart issues.  This flag will be
-                                ! deprecated in a future release.
+                                ! If true, then retain a legacy bug in the calculation of weights applied to
+                                ! isoneutral slopes. There was an erroneous k-indexing for layer thicknesses. In
+                                ! addition, masking at coastlines was not used which introduced potential
+                                ! restart issues.  This flag will be deprecated in a future release.
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic
-                                ! equatorial deformation radius, otherwise, if false, use
-                                ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
+                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
+                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 BULK_RI_ML_VISC = 0.05          !   [nondim] default = 0.05
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.  By default,
-                                ! BULK_RI_ML_VISC = BULK_RI_ML or 0.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.  By
+                                ! default, BULK_RI_ML_VISC = BULK_RI_ML or 0.
 TKE_DECAY_VISC = 10.0           !   [nondim] default = 10.0
-                                ! TKE_DECAY_VISC relates the vertical rate of decay of
-                                ! the TKE available for mechanical entrainment to the
-                                ! natural Ekman depth for use in calculating the dynamic
-                                ! mixed layer viscosity.  By default,
-                                ! TKE_DECAY_VISC = TKE_DECAY or 0.
+                                ! TKE_DECAY_VISC relates the vertical rate of decay of the TKE available for
+                                ! mechanical entrainment to the natural Ekman depth for use in calculating the
+                                ! dynamic mixed layer viscosity.  By default, TKE_DECAY_VISC = TKE_DECAY or 0.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.003                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
 SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
-                                ! The nondimensional Laplacian Smagorinsky constant used
-                                ! in calculating the channel drag if it is enabled.  The
-                                ! default is to use the same value as SMAG_LAP_CONST if
-                                ! it is defined, or 0.15 if it is not. The value used is
-                                ! also 0.15 if the specified value is negative.
+                                ! The nondimensional Laplacian Smagorinsky constant used in calculating the
+                                ! channel drag if it is enabled.  The default is to use the same value as
+                                ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
+                                ! 0.15 if the specified value is negative.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-06     !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -821,107 +737,98 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the S2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the S2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_N2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the N2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the N2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K2 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_K1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the K1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the K1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_O1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the O1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the O1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_P1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the P1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the P1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_Q1 = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the Q1
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the Q1 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MF = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MF
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MF frequency. This is only used
+                                ! if TIDES is true.
 TIDE_MM = False                 !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the MM
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the MM frequency. This is only used
+                                ! if TIDES is true.
 TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
-                                ! If true, read the tidal self-attraction and loading
-                                ! from input files, specified by TIDAL_INPUT_FILE.
-                                ! This is only used if TIDES is true.
+                                ! If true, read the tidal self-attraction and loading from input files,
+                                ! specified by TIDAL_INPUT_FILE. This is only used if TIDES is true.
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
-                                ! If true, use the SAL from the previous iteration of the
-                                ! tides to facilitate convergent iteration.
-                                ! This is only used if TIDES is true.
+                                ! If true, use the SAL from the previous iteration of the tides to facilitate
+                                ! convergent iteration. This is only used if TIDES is true.
 TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
-                                ! If true and TIDES is true, use the scalar approximation
-                                ! when calculating self-attraction and loading.
+                                ! If true and TIDES is true, use the scalar approximation when calculating
+                                ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 TIDE_M2_FREQ = 1.405189E-04     !   [s-1] default = 1.405189E-04
-                                ! Frequency of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Frequency of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_AMP = 0.242334          !   [m] default = 0.242334
-                                ! Amplitude of the M2 tidal constituent.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Amplitude of the M2 tidal constituent. This is only used if TIDES and TIDE_M2
+                                ! are true.
 TIDE_M2_PHASE_T0 = 0.0          !   [radians] default = 0.0
-                                ! Phase of the M2 tidal constituent at time 0.
-                                ! This is only used if TIDES and TIDE_M2 are true.
+                                ! Phase of the M2 tidal constituent at time 0. This is only used if TIDES and
+                                ! TIDE_M2 are true.
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -931,186 +838,156 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
-                                ! If true use a viscosity that increases with the square
-                                ! of the velocity shears, so that the resulting viscous
-                                ! drag is of comparable magnitude to the Coriolis terms
-                                ! when the velocity differences between adjacent grid
-                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
-                                ! value of BOUND_CORIOLIS (or false).
+                                ! If true use a viscosity that increases with the square of the velocity shears,
+                                ! so that the resulting viscous drag is of comparable magnitude to the Coriolis
+                                ! terms when the velocity differences between adjacent grid points is
+                                ! 0.5*BOUND_CORIOLIS_VEL.  The default is the value of BOUND_CORIOLIS (or
+                                ! false).
 BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
-                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
-                                ! the biharmonic drag to have comparable magnitude to the
-                                ! Coriolis acceleration.  The default is set by MAXVEL.
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes the biharmonic drag
+                                ! to have comparable magnitude to the Coriolis acceleration.  The default is set
+                                ! by MAXVEL.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1120,53 +997,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -1176,559 +1044,490 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
-                                ! INT_TIDE_PROFILE selects the vertical profile of energy
-                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
                                 !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an lee wave driven dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of Nikurashin
-                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
                                 ! and Simmons et al. (2004) vertical profile
 INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
-                                ! If true, consider mixing due to breaking low modes that
-                                ! have been remotely generated; as with itidal drag on the
-                                ! barotropic tide, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 MU_ITIDES = 0.2                 !   [nondim] default = 0.2
-                                ! A dimensionless turbulent mixing efficiency used with
-                                ! INT_TIDE_DISSIPATION, often 0.2.
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
 GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
-                                ! The fraction of the internal tidal energy that is
-                                ! dissipated locally with INT_TIDE_DISSIPATION.
-                                ! THIS NAME COULD BE BETTER.
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
 MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
-                                ! Turn off internal tidal dissipation when the total
-                                ! ocean depth is less than this value.
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
-                                ! The path to the file containing the spatially varying
-                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
                                 ! The thickness over which to apply geothermal heating.
 GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
-                                ! The value of drho_dT above which geothermal heating
-                                ! simply heats water in place instead of moving it between
-                                ! isopycnal layers.  This must be negative.
+                                ! The value of drho_dT above which geothermal heating simply heats water in
+                                ! place instead of moving it between isopycnal layers.  This must be negative.
 GEOTHERMAL_VARNAME = "geo_heat" ! default = "geo_heat"
-                                ! The name of the geothermal heating variable in
-                                ! GEOTHERMAL_FILE.
+                                ! The name of the geothermal heating variable in GEOTHERMAL_FILE.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
-                                ! The ratio of the typical Buoyancy frequency to twice
-                                ! the Earth's rotation period, used with the Henyey
-                                ! scaling from the mixing.
+                                ! The ratio of the typical Buoyancy frequency to twice the Earth's rotation
+                                ! period, used with the Henyey scaling from the mixing.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 LIMIT_BUFFER_DET_DH_SFC = 0.5   !   [nondim] default = 0.5
-                                ! The fractional limit in the change between grid points
-                                ! of the surface region (mixed & buffer layer) thickness.
+                                ! The fractional limit in the change between grid points of the surface region
+                                ! (mixed & buffer layer) thickness.
 LIMIT_BUFFER_DET_DH_BATHY = 0.2 !   [nondim] default = 0.2
-                                ! The fraction of the total depth by which the thickness
-                                ! of the surface region (mixed & buffer layer) is allowed
-                                ! to change between grid points.
+                                ! The fraction of the total depth by which the thickness of the surface region
+                                ! (mixed & buffer layer) is allowed to change between grid points.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1745,193 +1544,175 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 LONGWAVE_FORCING_VAR = "LW"     ! default = "LW"
                                 ! The variable with the longwave forcing field.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 SHORTWAVE_FORCING_VAR = "SW"    ! default = "SW"
                                 ! The variable with the shortwave forcing field.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 EVAP_FORCING_VAR = "evap"       ! default = "evap"
                                 ! The variable with the evaporative moisture flux.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 LATENT_FORCING_VAR = "latent"   ! default = "latent"
                                 ! The variable with the latent heat flux.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 SENSIBLE_FORCING_VAR = "sensible" ! default = "sensible"
                                 ! The variable with the sensible heat flux.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 RAIN_FORCING_VAR = "liq_precip" ! default = "liq_precip"
                                 ! The variable with the liquid precipitation flux.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 SNOW_FORCING_VAR = "froz_precip" ! default = "froz_precip"
                                 ! The variable with the frozen precipitation flux.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 LIQ_RUNOFF_FORCING_VAR = "liq_runoff" ! default = "liq_runoff"
                                 ! The variable with the liquid runoff flux.
 FROZ_RUNOFF_FORCING_VAR = "froz_runoff" ! default = "froz_runoff"
                                 ! The variable with the frozen runoff flux.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 SST_RESTORE_VAR = "SST"         ! default = "SST"
                                 ! The variable with the SST toward which to restore.
 SSS_RESTORE_VAR = "SSS"         ! default = "SSS"
                                 ! The variable with the SSS toward which to restore.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 WINDSTRESS_SCALE = 1.0          !   [nondim] default = 1.0
                                 ! A value by which the wind stresses in WIND_FILE are rescaled.
 USTAR_FORCING_VAR = ""          !   [nondim] default = ""
-                                ! The name of the friction velocity variable in WIND_FILE
-                                ! or blank to get ustar from the wind stresses plus the
-                                ! gustiness.
+                                ! The name of the friction velocity variable in WIND_FILE or blank to get ustar
+                                ! from the wind stresses plus the gustiness.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_T = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface temperature
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface temperature flux to the
+                                ! relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 FLUXCONST_S = 0.5               !   [m day-1] default = 0.5
-                                ! The constant that relates the restoring surface salinity
-                                ! flux to the relative surface anomaly (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface salinity flux to the relative
+                                ! surface anomaly (akin to a piston velocity).  Note the non-MKS units.
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1939,48 +1720,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1988,12 +1762,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/nonBous_global/MOM_parameter_doc.debugging
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.layout
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 10                     !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 6                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 10, 6                  !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -5,68 +5,56 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 7200.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = True            !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = True           !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 360                  !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 210                  !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -84,8 +72,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "mosaic"          !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -122,14 +110,14 @@ TOPO_CONFIG = "file"            !
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -181,8 +169,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "file"       !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -210,12 +198,11 @@ THICKNESS_CONFIG = "file"       !
 THICKNESS_FILE = "GOLD_IC.2010.11.15.nc" !
                                 ! The name of the thickness file.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 TS_CONFIG = "file"              !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -242,66 +229,58 @@ TS_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = True         !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 KHTH_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 VARMIX_KTOP = 6                 !   [nondim] default = 2
-                                ! The layer number at which to start vertical integration
-                                ! of S*N for purposes of finding the Eady growth rate.
+                                ! The layer number at which to start vertical integration of S*N for purposes of
+                                ! finding the Eady growth rate.
 VISBECK_L_SCALE = 3.0E+04       !   [m] default = 0.0
                                 ! The fixed length scale in the Visbeck formula.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = True       !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 
@@ -309,34 +288,30 @@ TIDES = True                    !   [Boolean] default = False
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2
-                                ! frequency. This is only used if TIDES is true.
+                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
+                                ! if TIDES is true.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface
-                                ! height (really it should be bottom pressure) anomalies
-                                ! and bottom geopotential anomalies. This is only used if
-                                ! TIDES and TIDE_USE_SAL_SCALAR are true.
+                                ! The constant of proportionality between sea surface height (really it should
+                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
+                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 
@@ -346,57 +321,46 @@ TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 
 ! === module MOM_vert_friction ===
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.95                    !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -406,28 +370,24 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
-                                ! A nondimensional coefficient that is proportional to
-                                ! the ratio of the deformation radius to the dominant
-                                ! lengthscale of the submesoscale mixed layer
-                                ! instabilities, times the minimum of the ratio of the
-                                ! mesoscale eddy kinetic energy to the large-scale
-                                ! geostrophic kinetic energy or 1 plus the square of the
-                                ! grid spacing over the deformation radius, as detailed
-                                ! by Fox-Kemper et al. (2010)
+                                ! A nondimensional coefficient that is proportional to the ratio of the
+                                ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
+                                ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
+                                ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
+                                ! (2010)
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -439,97 +399,88 @@ Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
-                                ! The decay scale away from the bottom for tidal TKE with
-                                ! the new coding when INT_TIDE_DISSIPATION is used.
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
-                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
-                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with
-                                ! INT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source available to mix
-                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
 H2_FILE = "sgs_h2.nc"           !
-                                ! The path to the file containing the sub-grid-scale
-                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_geothermal ===
 GEOTHERMAL_SCALE = 0.001        !   [W m-2 or various] default = 0.0
-                                ! The constant geothermal heat flux, a rescaling
-                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
-                                ! 0 to disable the geothermal heating.
+                                ! The constant geothermal heat flux, a rescaling factor for the heat flux read
+                                ! from GEOTHERMAL_FILE, or 0 to disable the geothermal heating.
 GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
-                                ! The file from which the geothermal heating is to be
-                                ! read, or blank to use a constant heating rate.
+                                ! The file from which the geothermal heating is to be read, or blank to use a
+                                ! constant heating rate.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_COEFF = 0.1              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 MSTAR = 0.3                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 DISSIPATION_N0 = 1.0E-07        !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 6.0E-04        !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -542,51 +493,45 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = True     !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = True                !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 ML_PRESORT_NK_CONV_ADJ = 4      !   [nondim] default = 0
-                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ
-                                ! layers before sorting when ML_RESORT is true.
+                                ! Convectively mix the first ML_PRESORT_NK_CONV_ADJ layers before sorting when
+                                ! ML_RESORT is true.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
-                                ! The depth to which rivers are mixed if DO_RIVERMIX is
-                                ! defined.
+                                ! The depth to which rivers are mixed if DO_RIVERMIX is defined.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "seawifs_1998-2006_GOLD_smoothed_2X.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -600,133 +545,116 @@ KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
 KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 ML_KHTR_SCALE = 0.0             !   [nondim] default = 1.0
-                                ! With Diffuse_ML_interior, the ratio of the truly
-                                ! horizontal diffusivity in the mixed layer to the
-                                ! epipycnal diffusivity.  The valid range is 0 to 1.
+                                ! With Diffuse_ML_interior, the ratio of the truly horizontal diffusivity in the
+                                ! mixed layer to the epipycnal diffusivity.  The valid range is 0 to 1.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
+                                ! If true, use the forcing variable decomposition from the old German OMIP
+                                ! prescription that predated CORE. If false, use the variable groupings
+                                ! available from MOM output diagnostics of forcing variables.
 LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
+                                ! The file with the longwave heat flux, in the variable given by
+                                ! LONGWAVE_FORCING_VAR.
 SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
+                                ! The file with the shortwave heat flux, in the variable given by
+                                ! SHORTWAVE_FORCING_VAR.
 EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
+                                ! The file with the evaporative moisture flux, in the variable given by
+                                ! EVAP_FORCING_VAR.
 LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
+                                ! The file with the latent heat flux, in the variable given by
+                                ! LATENT_FORCING_VAR.
 SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
+                                ! The file with the sensible heat flux, in the variable given by
+                                ! SENSIBLE_FORCING_VAR.
 RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
+                                ! The file with the liquid precipitation flux, in the variable given by
+                                ! RAIN_FORCING_VAR.
 SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
+                                ! The file with the frozen precipitation flux, in the variable given by
+                                ! SNOW_FORCING_VAR.
 RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
+                                ! The file with the fresh and frozen runoff/calving fluxes, in variables given
+                                ! by LIQ_RUNOFF_FORCING_VAR and FROZ_RUNOFF_FORCING_VAR.
 SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
+                                ! The file with the SST toward which to restore in the variable given by
+                                ! SST_RESTORE_VAR.
 SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
+                                ! The file with the surface salinity toward which to restore in the variable
+                                ! given by SSS_RESTORE_VAR.
 WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
+                                ! The file in which the wind stresses are found in variables STRESS_X and
+                                ! STRESS_Y.
 WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
                                 ! The name of the x-wind stress variable in WIND_FILE.
 WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
                                 ! The name of the y-wind stress variable in WIND_FILE.
 WINDSTRESS_STAGGER = "C"        ! default = "A"
-                                ! A character indicating how the wind stress components
-                                ! are staggered in WIND_FILE.  This may be A or C for now.
+                                ! A character indicating how the wind stress components are staggered in
+                                ! WIND_FILE.  This may be A or C for now.
 RESTOREBUOY = True              !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 FLUXCONST = 0.5                 !   [m day-1]
-                                ! The constant that relates the restoring surface fluxes
-                                ! to the relative surface anomalies (akin to a piston
-                                ! velocity).  Note the non-MKS units.
+                                ! The constant that relates the restoring surface fluxes to the relative surface
+                                ! anomalies (akin to a piston velocity).  Note the non-MKS units.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "gustiness_qscat.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 365.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 9                          !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,11 +352,9 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -402,12 +363,11 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -433,8 +393,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "linear"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -461,8 +421,8 @@ S_TOP = 34.0                    !   [PSU]
 S_RANGE = 2.0                   !   [PSU]
                                 ! Initial salinity difference (top-bottom).
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -472,41 +432,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -522,113 +479,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -636,106 +578,89 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 4.5E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -743,50 +668,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -796,159 +715,133 @@ KH = 1.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -958,53 +851,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1014,363 +898,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.01                !   [m2 s-1] default = 0.01
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 0.0010954451150103 !   [m] default = 0.0010954451150103
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.1                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.001                  !   [m2 s-1] default = 0.001
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.1                      !   [m2 s-1] default = 0.1
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.1          !   [m2 s-1] default = 0.1
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1387,91 +1228,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1479,8 +1311,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1488,48 +1319,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 1000.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1537,12 +1361,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/resting/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/resting/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/resting/layer/MOM_parameter_doc.layout
+++ b/ocean_only/resting/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/resting/layer/MOM_parameter_doc.short
+++ b/ocean_only/resting/layer/MOM_parameter_doc.short
@@ -5,37 +5,30 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -51,8 +44,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -64,8 +57,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -102,8 +95,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -115,17 +108,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -152,8 +142,7 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -162,8 +151,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -189,8 +178,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "linear"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -225,62 +214,54 @@ S_RANGE = 2.0                   !   [PSU]
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 4.5E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -293,58 +274,48 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0                        !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -369,22 +340,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.1                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -402,11 +370,10 @@ KD = 0.1                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -417,9 +384,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -428,45 +394,38 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 1000.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 1200.0               !   [s] default = 1200.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 9                          !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,8 +374,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -435,46 +394,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -485,12 +438,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -516,8 +468,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "linear"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -544,8 +496,8 @@ S_TOP = 34.0                    !   [PSU]
 S_RANGE = 2.0                   !   [PSU]
                                 ! Initial salinity difference (top-bottom).
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -555,45 +507,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -609,113 +558,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -723,106 +657,89 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 4.5E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -830,50 +747,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -883,159 +794,133 @@ KH = 1.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1045,53 +930,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1101,363 +977,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.01                !   [m2 s-1] default = 0.01
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 0.0010954451150103 !   [m] default = 0.0010954451150103
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.1                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.001                  !   [m2 s-1] default = 0.001
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.1                      !   [m2 s-1] default = 0.1
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.1          !   [m2 s-1] default = 0.1
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1474,91 +1307,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1566,8 +1390,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1575,48 +1398,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 1000.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1624,12 +1440,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/resting/z/MOM_parameter_doc.debugging
+++ b/ocean_only/resting/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/resting/z/MOM_parameter_doc.layout
+++ b/ocean_only/resting/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -5,33 +5,28 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 1200.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -47,8 +42,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -60,8 +55,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -98,8 +93,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -111,17 +106,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -148,14 +140,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -175,8 +165,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -202,8 +192,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "linear"            !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -238,62 +228,54 @@ S_RANGE = 2.0                   !   [PSU]
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 4.5E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -306,58 +288,48 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1.0                        !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 DT_BT_FILTER = 0.0              !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 60.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -382,22 +354,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.1                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -415,11 +384,10 @@ KD = 0.1                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -430,9 +398,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -441,45 +408,38 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 1000.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 20                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,27 +221,27 @@ TOPO_CONFIG = "seamount"        !
 SEAMOUNT_DELTA = 0.5            !   [non-dim] default = 0.5
                                 ! Non-dimensional height of seamount.
 SEAMOUNT_X_LENGTH_SCALE = 20.0  !   [Same as x,y] default = 20.0
-                                ! Length scale of seamount in x-direction.
-                                ! Set to zero make topography uniform in the x-direction.
+                                ! Length scale of seamount in x-direction. Set to zero make topography uniform
+                                ! in the x-direction.
 SEAMOUNT_Y_LENGTH_SCALE = 0.0   !   [Same as x,y] default = 0.0
-                                ! Length scale of seamount in y-direction.
-                                ! Set to zero make topography uniform in the y-direction.
+                                ! Length scale of seamount in y-direction. Set to zero make topography uniform
+                                ! in the y-direction.
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -402,23 +365,20 @@ COORD_CONFIG = "ts_range"       !
 T_REF = 0.0                     !   [degC] default = 10.0
                                 ! The default initial temperatures.
 TS_RANGE_T_LIGHT = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_RESOLN_RATIO = 1.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
@@ -428,12 +388,11 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -461,11 +420,11 @@ THICKNESS_CONFIG = "seamount"   !
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
                                 ! Minimum thickness for layer
 INTERFACE_IC_QUANTA = 2048.0    !   [m-1] default = 2048.0
-                                ! The granularity of initial interface height values
-                                ! per meter, to avoid sensivity to order-of-arithmetic changes.
+                                ! The granularity of initial interface height values per meter, to avoid
+                                ! sensivity to order-of-arithmetic changes.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -484,8 +443,8 @@ TS_CONFIG = "seamount"          !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 INITIAL_DENSITY_PROFILE = "linear" ! default = "linear"
-                                ! Initial profile shape. Valid values are "linear", "parabolic"
-                                ! and "exponential".
+                                ! Initial profile shape. Valid values are "linear", "parabolic" and
+                                ! "exponential".
 INITIAL_SSS = 34.0              !   [1e-3] default = 34.0
                                 ! Initial surface salinity
 INITIAL_SST = 0.0               !   [C] default = 0.0
@@ -495,8 +454,8 @@ INITIAL_S_RANGE = 2.0           !   [1e-3] default = 2.0
 INITIAL_T_RANGE = 0.0           !   [C] default = 0.0
                                 ! Initial temperature range (bottom - surface)
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -506,41 +465,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -556,113 +512,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -670,106 +611,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -777,50 +701,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -830,159 +748,133 @@ KH = 1000.0                     !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -992,53 +884,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1048,363 +931,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1421,91 +1261,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1513,8 +1344,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1522,48 +1352,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1571,12 +1394,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/seamount/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/seamount/layer/MOM_parameter_doc.layout
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/seamount/layer/MOM_parameter_doc.short
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.short
@@ -5,25 +5,20 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -31,13 +26,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -53,8 +46,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -66,8 +59,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -101,14 +94,14 @@ TOPO_CONFIG = "seamount"        !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -120,17 +113,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -161,19 +151,17 @@ T_REF = 0.0                     !   [degC] default = 10.0
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -201,8 +189,8 @@ THICKNESS_CONFIG = "seamount"   !
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
                                 ! Minimum thickness for layer
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -229,66 +217,57 @@ TS_CONFIG = "seamount"          !
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -301,42 +280,36 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1000.0                     !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -346,20 +319,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -384,22 +354,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -417,11 +384,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -432,9 +398,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -443,49 +408,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 20                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,27 +221,27 @@ TOPO_CONFIG = "seamount"        !
 SEAMOUNT_DELTA = 0.5            !   [non-dim] default = 0.5
                                 ! Non-dimensional height of seamount.
 SEAMOUNT_X_LENGTH_SCALE = 20.0  !   [Same as x,y] default = 20.0
-                                ! Length scale of seamount in x-direction.
-                                ! Set to zero make topography uniform in the x-direction.
+                                ! Length scale of seamount in x-direction. Set to zero make topography uniform
+                                ! in the x-direction.
 SEAMOUNT_Y_LENGTH_SCALE = 0.0   !   [Same as x,y] default = 0.0
-                                ! Length scale of seamount in y-direction.
-                                ! Set to zero make topography uniform in the y-direction.
+                                ! Length scale of seamount in y-direction. Set to zero make topography uniform
+                                ! in the y-direction.
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -402,34 +365,30 @@ COORD_CONFIG = "ts_range"       !
 T_REF = 0.0                     !   [degC] default = 10.0
                                 ! The default initial temperatures.
 TS_RANGE_T_LIGHT = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_RESOLN_RATIO = 1.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -440,12 +399,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -456,14 +413,11 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -485,12 +439,10 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1034.0, 1034.1, 1034.1999999999998, 1034.2999999999997, 1034.3999999999996, 1034.4999999999995, 1034.5999999999995, 1034.6999999999994, 1034.7999999999993, 1034.8999999999992, 1034.999999999999, 1035.099999999999, 1035.199999999999, 1035.2999999999988, 1035.3999999999987, 1035.4999999999986, 1035.5999999999985, 1035.6999999999985, 1035.7999999999984, 1035.8999999999983, 1036.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 1.0E-09         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "NONE" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -510,43 +462,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -557,12 +504,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -588,11 +534,11 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 INTERFACE_IC_QUANTA = 2048.0    !   [m-1] default = 2048.0
-                                ! The granularity of initial interface height values
-                                ! per meter, to avoid sensivity to order-of-arithmetic changes.
+                                ! The granularity of initial interface height values per meter, to avoid
+                                ! sensivity to order-of-arithmetic changes.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -611,8 +557,8 @@ TS_CONFIG = "seamount"          !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 INITIAL_DENSITY_PROFILE = "linear" ! default = "linear"
-                                ! Initial profile shape. Valid values are "linear", "parabolic"
-                                ! and "exponential".
+                                ! Initial profile shape. Valid values are "linear", "parabolic" and
+                                ! "exponential".
 INITIAL_SSS = 34.0              !   [1e-3] default = 34.0
                                 ! Initial surface salinity
 INITIAL_SST = 0.0               !   [C] default = 0.0
@@ -622,8 +568,8 @@ INITIAL_S_RANGE = 2.0           !   [1e-3] default = 2.0
 INITIAL_T_RANGE = 0.0           !   [C] default = 0.0
                                 ! Initial temperature range (bottom - surface)
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -633,45 +579,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -687,113 +630,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -801,106 +729,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -908,50 +819,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -961,159 +866,133 @@ KH = 1000.0                     !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1123,53 +1002,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1179,363 +1049,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1552,91 +1379,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1644,8 +1462,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1653,48 +1470,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1702,12 +1512,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/seamount/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/seamount/rho/MOM_parameter_doc.layout
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -5,21 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -27,13 +24,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -49,8 +44,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -62,8 +57,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -97,14 +92,14 @@ TOPO_CONFIG = "seamount"        !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -116,17 +111,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,15 +149,12 @@ T_REF = 0.0                     !   [degC] default = 10.0
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -174,12 +163,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -190,11 +177,9 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 !ALE_RESOLUTION = 20*0.1        !   [kg m^-3]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
@@ -204,13 +189,11 @@ BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
 !TARGET_DENSITIES = 1034.0, 1034.1, 1034.1999999999998, 1034.2999999999997, 1034.3999999999996, 1034.4999999999995, 1034.5999999999995, 1034.6999999999994, 1034.7999999999993, 1034.8999999999992, 1034.999999999999, 1035.099999999999, 1035.199999999999, 1035.2999999999988, 1035.3999999999987, 1035.4999999999986, 1035.5999999999985, 1035.6999999999985, 1035.7999999999984, 1035.8999999999983, 1036.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 MIN_THICKNESS = 1.0E-09         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -222,8 +205,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -249,8 +232,8 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -277,75 +260,65 @@ TS_CONFIG = "seamount"          !
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -353,42 +326,36 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1000.0                     !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -398,20 +365,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -436,22 +400,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -469,11 +430,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -484,9 +444,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -495,49 +454,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 20                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,27 +221,27 @@ TOPO_CONFIG = "seamount"        !
 SEAMOUNT_DELTA = 0.5            !   [non-dim] default = 0.5
                                 ! Non-dimensional height of seamount.
 SEAMOUNT_X_LENGTH_SCALE = 20.0  !   [Same as x,y] default = 20.0
-                                ! Length scale of seamount in x-direction.
-                                ! Set to zero make topography uniform in the x-direction.
+                                ! Length scale of seamount in x-direction. Set to zero make topography uniform
+                                ! in the x-direction.
 SEAMOUNT_Y_LENGTH_SCALE = 0.0   !   [Same as x,y] default = 0.0
-                                ! Length scale of seamount in y-direction.
-                                ! Set to zero make topography uniform in the y-direction.
+                                ! Length scale of seamount in y-direction. Set to zero make topography uniform
+                                ! in the y-direction.
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -402,34 +365,30 @@ COORD_CONFIG = "ts_range"       !
 T_REF = 0.0                     !   [degC] default = 10.0
                                 ! The default initial temperatures.
 TS_RANGE_T_LIGHT = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_RESOLN_RATIO = 1.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -440,8 +399,7 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "Non-dimensional" ! default = "Non-dimensional"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -461,46 +419,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -511,12 +463,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -542,8 +493,8 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -562,8 +513,8 @@ TS_CONFIG = "seamount"          !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 INITIAL_DENSITY_PROFILE = "linear" ! default = "linear"
-                                ! Initial profile shape. Valid values are "linear", "parabolic"
-                                ! and "exponential".
+                                ! Initial profile shape. Valid values are "linear", "parabolic" and
+                                ! "exponential".
 INITIAL_SSS = 34.0              !   [1e-3] default = 34.0
                                 ! Initial surface salinity
 INITIAL_SST = 0.0               !   [C] default = 0.0
@@ -573,8 +524,8 @@ INITIAL_S_RANGE = 2.0           !   [1e-3] default = 2.0
 INITIAL_T_RANGE = 0.0           !   [C] default = 0.0
                                 ! Initial temperature range (bottom - surface)
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -584,45 +535,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -638,113 +586,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -752,106 +685,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -859,50 +775,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -912,159 +822,133 @@ KH = 1000.0                     !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1074,53 +958,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1130,363 +1005,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1503,91 +1335,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1595,8 +1418,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1604,48 +1426,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1653,12 +1468,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.layout
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -5,21 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -27,13 +24,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -49,8 +44,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -62,8 +57,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -97,14 +92,14 @@ TOPO_CONFIG = "seamount"        !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -116,17 +111,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,15 +149,12 @@ T_REF = 0.0                     !   [degC] default = 10.0
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -180,13 +169,11 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -198,8 +185,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -225,8 +212,8 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -253,66 +240,57 @@ TS_CONFIG = "seamount"          !
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -325,42 +303,36 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1000.0                     !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -370,20 +342,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -408,22 +377,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -441,11 +407,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -456,9 +421,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -467,49 +431,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 20                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,27 +221,27 @@ TOPO_CONFIG = "seamount"        !
 SEAMOUNT_DELTA = 0.5            !   [non-dim] default = 0.5
                                 ! Non-dimensional height of seamount.
 SEAMOUNT_X_LENGTH_SCALE = 20.0  !   [Same as x,y] default = 20.0
-                                ! Length scale of seamount in x-direction.
-                                ! Set to zero make topography uniform in the x-direction.
+                                ! Length scale of seamount in x-direction. Set to zero make topography uniform
+                                ! in the x-direction.
 SEAMOUNT_Y_LENGTH_SCALE = 0.0   !   [Same as x,y] default = 0.0
-                                ! Length scale of seamount in y-direction.
-                                ! Set to zero make topography uniform in the y-direction.
+                                ! Length scale of seamount in y-direction. Set to zero make topography uniform
+                                ! in the y-direction.
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -287,71 +260,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -371,8 +334,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -402,34 +365,30 @@ COORD_CONFIG = "ts_range"       !
 T_REF = 0.0                     !   [degC] default = 10.0
                                 ! The default initial temperatures.
 TS_RANGE_T_LIGHT = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the lightest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the lightest layer when COORD_CONFIG is set to
+                                ! ts_range.
 TS_RANGE_T_DENSE = 0.0          !   [degC] default = 0.0
-                                ! The initial temperature of the densest layer when
-                                ! COORD_CONFIG is set to ts_range.
+                                ! The initial temperature of the densest layer when COORD_CONFIG is set to
+                                ! ts_range.
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_RESOLN_RATIO = 1.0     !   [nondim] default = 1.0
-                                ! The ratio of density space resolution in the densest
-                                ! part of the range to that in the lightest part of the
-                                ! range when COORD_CONFIG is set to ts_range. Values
+                                ! The ratio of density space resolution in the densest part of the range to that
+                                ! in the lightest part of the range when COORD_CONFIG is set to ts_range. Values
                                 ! greater than 1 increase the resolution of the denser water.
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -440,8 +399,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -461,46 +419,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -511,12 +463,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -542,8 +493,8 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -562,8 +513,8 @@ TS_CONFIG = "seamount"          !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 INITIAL_DENSITY_PROFILE = "linear" ! default = "linear"
-                                ! Initial profile shape. Valid values are "linear", "parabolic"
-                                ! and "exponential".
+                                ! Initial profile shape. Valid values are "linear", "parabolic" and
+                                ! "exponential".
 INITIAL_SSS = 34.0              !   [1e-3] default = 34.0
                                 ! Initial surface salinity
 INITIAL_SST = 0.0               !   [C] default = 0.0
@@ -573,8 +524,8 @@ INITIAL_S_RANGE = 2.0           !   [1e-3] default = 2.0
 INITIAL_T_RANGE = 0.0           !   [C] default = 0.0
                                 ! Initial temperature range (bottom - surface)
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -584,45 +535,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -638,113 +586,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -752,106 +685,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -859,50 +775,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -912,159 +822,133 @@ KH = 1000.0                     !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1074,53 +958,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1130,363 +1005,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1503,91 +1335,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1595,8 +1418,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1604,48 +1426,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1653,12 +1468,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/seamount/z/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/seamount/z/MOM_parameter_doc.layout
+++ b/ocean_only/seamount/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -5,21 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -27,13 +24,11 @@ IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -49,8 +44,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -62,8 +57,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 10.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -97,14 +92,14 @@ TOPO_CONFIG = "seamount"        !
 MAXIMUM_DEPTH = 4000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -116,17 +111,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -157,15 +149,12 @@ T_REF = 0.0                     !   [degC] default = 10.0
 S_REF = 34.0                    !   [PSU] default = 35.0
                                 ! The default initial salinities.
 TS_RANGE_S_LIGHT = 34.05        !   [PSU] default = 34.0
-                                ! The initial lightest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial lightest salinities when COORD_CONFIG is set to ts_range.
 TS_RANGE_S_DENSE = 35.95        !   [PSU] default = 34.0
-                                ! The initial densest salinities when COORD_CONFIG
-                                ! is set to ts_range.
+                                ! The initial densest salinities when COORD_CONFIG is set to ts_range.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -180,13 +169,11 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -198,8 +185,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "seamount"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -225,8 +212,8 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "seamount"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -253,66 +240,57 @@ TS_CONFIG = "seamount"          !
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.002                   !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.05              !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 1.0E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -325,42 +303,36 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 1000.0                     !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -370,20 +342,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -408,22 +377,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -441,11 +407,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -456,9 +421,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -467,49 +431,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 10.0                  !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -9,140 +9,117 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = True           !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 NKML = 2                        !   [nondim] default = 2
-                                ! The number of sublayers within the mixed layer if
-                                ! BULKMIXEDLAYER is true.
+                                ! The number of sublayers within the mixed layer if BULKMIXEDLAYER is true.
 NKBL = 2                        !   [nondim] default = 2
-                                ! The number of layers that are used as variable density
-                                ! buffer layers if BULKMIXEDLAYER is true.
+                                ! The number of layers that are used as variable density buffer layers if
+                                ! BULKMIXEDLAYER is true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -150,16 +127,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -169,17 +144,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
@@ -189,8 +162,8 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -202,13 +175,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -245,13 +218,13 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -270,60 +243,53 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -343,8 +309,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -376,65 +342,54 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 COORD_FILE = "../isopyc_coords.nc" !
                                 ! The file from which the coordinate densities are read.
 COORD_VAR = "Layer"             ! default = "Layer"
-                                ! The variable in COORD_FILE that is to be used for the
-                                ! coordinate densities.
+                                ! The variable in COORD_FILE that is to be used for the coordinate densities.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = False    !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 FIT_TO_TARGET_DENSITY_IC = True !   [Boolean] default = True
-                                ! If true, all the interior layers are adjusted to
-                                ! their target densities using mostly temperature
-                                ! This approach can be problematic, particularly in the
-                                ! high latitudes.
+                                ! If true, all the interior layers are adjusted to their target densities using
+                                ! mostly temperature This approach can be problematic, particularly in the high
+                                ! latitudes.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -444,41 +399,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -494,113 +446,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -610,82 +547,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 3.15E-09        !   [m] default = 3.15E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 3.15E-09
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -693,108 +618,93 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -806,468 +716,411 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 ML_MIX_FIRST = 0.0              !   [nondim] default = 0.0
-                                ! The fraction of the mixed layer mixing that is applied
-                                ! before interior diapycnal mixing.  0 by default.
+                                ! The fraction of the mixed layer mixing that is applied before interior
+                                ! diapycnal mixing.  0 by default.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.2              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 KAPPA_SHEAR_MERGE_ML = True     !   [Boolean] default = True
-                                ! If true, combine the mixed layers together before
-                                ! solving the kappa-shear equations.
+                                ! If true, combine the mixed layers together before solving the kappa-shear
+                                ! equations.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 
 ! === module MOM_mixed_layer ===
 NSTAR = 0.15                    !   [nondim] default = 0.15
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 NSTAR2 = 0.15                   !   [nondim] default = 0.15
-                                ! The portion of any potential energy released by
-                                ! convective adjustment that is available to drive
-                                ! entrainment at the base of mixed layer. By default
+                                ! The portion of any potential energy released by convective adjustment that is
+                                ! available to drive entrainment at the base of mixed layer. By default
                                 ! NSTAR2=NSTAR.
 BULK_RI_CONVECTIVE = 0.05       !   [nondim] default = 0.05
-                                ! The efficiency with which convectively released mean
-                                ! kinetic energy is converted to turbulent kinetic
-                                ! energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.
+                                ! The efficiency with which convectively released mean kinetic energy is
+                                ! converted to turbulent kinetic energy.  By default
+                                ! BULK_RI_CONVECTIVE=BULK_RI_ML.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 LIMIT_BUFFER_DETRAIN = False    !   [Boolean] default = False
-                                ! If true, limit the detrainment from the buffer layers
-                                ! to not be too different from the neighbors.
+                                ! If true, limit the detrainment from the buffer layers to not be too different
+                                ! from the neighbors.
 ALLOWED_DETRAIN_TEMP_CHG = 0.5  !   [K] default = 0.5
-                                ! The amount by which temperature is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which temperature is allowed to exceed previous values during
+                                ! detrainment.
 ALLOWED_DETRAIN_SALT_CHG = 0.1  !   [PSU] default = 0.1
-                                ! The amount by which salinity is allowed to exceed
-                                ! previous values during detrainment.
+                                ! The amount by which salinity is allowed to exceed previous values during
+                                ! detrainment.
 ML_DT_DS_WEIGHT = 6.0           !   [degC PSU-1] default = 6.0
-                                ! When forced to extrapolate T & S to match the layer
-                                ! densities, this factor (in deg C / PSU) is combined
-                                ! with the derivatives of density with T & S to determine
-                                ! what direction is orthogonal to density contours. It
-                                ! should be a typical value of (dR/dS) / (dR/dT) in
-                                ! oceanic profiles.
+                                ! When forced to extrapolate T & S to match the layer densities, this factor (in
+                                ! deg C / PSU) is combined with the derivatives of density with T & S to
+                                ! determine what direction is orthogonal to density contours. It should be a
+                                ! typical value of (dR/dS) / (dR/dT) in oceanic profiles.
 BUFFER_LAYER_EXTRAP_LIMIT = -1.0 !   [nondim] default = -1.0
-                                ! A limit on the density range over which extrapolation
-                                ! can occur when detraining from the buffer layers,
-                                ! relative to the density range within the mixed and
-                                ! buffer layers, when the detrainment is going into the
-                                ! lightest interior layer, nondimensional, or a negative
-                                ! value not to apply this limit.
+                                ! A limit on the density range over which extrapolation can occur when
+                                ! detraining from the buffer layers, relative to the density range within the
+                                ! mixed and buffer layers, when the detrainment is going into the lightest
+                                ! interior layer, nondimensional, or a negative value not to apply this limit.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 ML_RESORT = False               !   [Boolean] default = False
-                                ! If true, resort the topmost layers by potential density
-                                ! before the mixed layer calculations.
+                                ! If true, resort the topmost layers by potential density before the mixed layer
+                                ! calculations.
 BML_USTAR_MIN = 1.45842E-18     !   [m s-1] default = 1.45842E-18
-                                ! The minimum value of ustar that should be used by the
-                                ! bulk mixed layer model in setting vertical TKE decay
-                                ! scales. This must be greater than 0.
+                                ! The minimum value of ustar that should be used by the bulk mixed layer model
+                                ! in setting vertical TKE decay scales. This must be greater than 0.
 RESOLVE_EKMAN = False           !   [Boolean] default = False
-                                ! If true, the NKML>1 layers in the mixed layer are
-                                ! chosen to optimally represent the impact of the Ekman
-                                ! transport on the mixed layer TKE budget.  Otherwise,
-                                ! the sublayers are distributed uniformly through the
-                                ! mixed layer.
+                                ! If true, the NKML>1 layers in the mixed layer are chosen to optimally
+                                ! represent the impact of the Ekman transport on the mixed layer TKE budget.
+                                ! Otherwise, the sublayers are distributed uniformly through the mixed layer.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH, if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1284,91 +1137,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1376,11 +1220,9 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1388,48 +1230,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1437,12 +1272,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/single_column/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.layout
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -7,40 +7,33 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -56,16 +49,16 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1.0                    !   [degrees]
@@ -102,8 +95,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -111,8 +104,7 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
@@ -149,29 +141,23 @@ COORD_FILE = "../isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 ADJUST_THICKNESS = True         !   [Boolean] default = False
-                                ! If true, all mass below the bottom removed if the
-                                ! topography is shallower than the thickness input file
-                                ! would indicate.
+                                ! If true, all mass below the bottom removed if the topography is shallower than
+                                ! the thickness input file would indicate.
 
 ! === module MOM_diag_mediator ===
 
@@ -181,58 +167,50 @@ ADJUST_THICKNESS = True         !   [Boolean] default = False
 
 ! === module MOM_set_visc ===
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 3.15E-09
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -241,21 +219,19 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -265,12 +241,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -287,42 +262,39 @@ Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -333,42 +305,37 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_mixed_layer ===
 BULK_RI_ML = 0.05               !   [nondim]
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 ABSORB_ALL_SW = True            !   [Boolean] default = False
-                                ! If true,  all shortwave radiation is absorbed by the
-                                ! ocean, instead of passing through to the bottom mud.
+                                ! If true,  all shortwave radiation is absorbed by the ocean, instead of passing
+                                ! through to the bottom mud.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 DEPTH_LIMIT_FLUXES = 0.1        !   [m] default = 0.2
-                                ! The surface fluxes are scaled away when the total ocean
-                                ! depth is less than DEPTH_LIMIT_FLUXES.
+                                ! The surface fluxes are scaled away when the total ocean depth is less than
+                                ! DEPTH_LIMIT_FLUXES.
 CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
-                                ! If true, the average depth at which penetrating shortwave
-                                ! radiation is absorbed is adjusted to match the average
-                                ! heating depth of an exponential profile by moving some
-                                ! of the heating upward in the water column.
+                                ! If true, the average depth at which penetrating shortwave radiation is
+                                ! absorbed is adjusted to match the average heating depth of an exponential
+                                ! profile by moving some of the heating upward in the water column.
 
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -383,58 +350,48 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,60 +246,53 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -345,8 +312,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -376,13 +343,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -393,8 +359,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -414,46 +379,40 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -464,48 +423,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -515,45 +466,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -569,113 +517,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -685,82 +618,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -768,116 +689,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -889,123 +793,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = True                  !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = False !   [Boolean] default = False
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1019,28 +911,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1048,21 +937,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "CVMix"             ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1074,15 +963,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1091,257 +980,225 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.2              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
-                                ! If true, the model does not check if fluxes are being applied
-                                ! over land points. This is needed when the ocean is coupled
-                                ! with ice shelves and sea ice, since the sea ice mask needs to
-                                ! be different than the ocean mask to avoid sea ice formation
-                                ! under ice shelves. This flag only works when use_ePBL = True.
+                                ! If true, the model does not check if fluxes are being applied over land
+                                ! points. This is needed when the ocean is coupled with ice shelves and sea ice,
+                                ! since the sea ice mask needs to be different than the ocean mask to avoid sea
+                                ! ice formation under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing wherever there is
-                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
-                                ! if the ocean is that deep.
+                                ! If true, apply additional mixing wherever there is runoff, so that it is mixed
+                                ! down to RIVERMIX_DEPTH if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_energetic_PBL ===
 MSTAR_MODE = 0                  !   [units=nondim] default = 0
@@ -1350,139 +1207,125 @@ MSTAR_MODE = 0                  !   [units=nondim] default = 0
                                 !     1 for MSTAR w/ MLD in stabilizing limit
                                 !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
 MIX_LEN_EXPONENT = 2.0          !   [units=nondim] default = 2.0
-                                ! The exponent applied to the ratio of the distance to the MLD
-                                ! and the MLD depth which determines the shape of the mixing length.
+                                ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
+                                ! which determines the shape of the mixing length.
 MSTAR_CAP = -1.0                !   [units=nondim] default = -1.0
-                                ! Maximum value of mstar allowed in model if non-negative
-                                ! (used if MSTAR_MODE>0).
+                                ! Maximum value of mstar allowed in model if non-negative (used if
+                                ! MSTAR_MODE>0).
 MSTAR_CONV_ADJ = 0.0            !   [units=nondim] default = 0.0
-                                ! Factor used for reducing mstar during convection
-                                !  due to reduction of stable density gradient.
+                                ! Factor used for reducing mstar during convection due to reduction of stable
+                                ! density gradient.
 MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
-                                ! The slope of the linear relationship between mstar
-                                ! and the length scale ratio (used if MSTAR_MODE=1).
-MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
-                                ! The value of the length scale ratio where the mstar
-                                ! is linear above (used if MSTAR_MODE=1).
-MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
-                                ! The value of mstar at MSTAR_XINT
+                                ! The slope of the linear relationship between mstar and the length scale ratio
                                 ! (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar is linear above (used if
+                                ! MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT (used if MSTAR_MODE=1).
 MSTAR_FLATCAP = True            !   [units=nondim] default = True
-                                ! Set false to use asymptotic cap, defaults to true.
-                                ! (used only if MSTAR_MODE=1)
+                                ! Set false to use asymptotic cap, defaults to true. (used only if MSTAR_MODE=1)
 MSTAR2_COEF1 = 0.3              !   [units=nondim] default = 0.3
-                                ! Coefficient in computing mstar when rotation and
-                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when rotation and stabilizing effects are both
+                                ! important (used if MSTAR_MODE=2)
 MSTAR2_COEF2 = 0.085            !   [units=nondim] default = 0.085
-                                ! Coefficient in computing mstar when only rotation limits
-                                !  the total mixing. (used only if MSTAR_MODE=2)
+                                ! Coefficient in computing mstar when only rotation limits the total mixing.
+                                ! (used only if MSTAR_MODE=2)
 NSTAR = 0.2                     !   [nondim] default = 0.2
-                                ! The portion of the buoyant potential energy imparted by
-                                ! surface fluxes that is available to drive entrainment
-                                ! at the base of mixed layer when that energy is positive.
+                                ! The portion of the buoyant potential energy imparted by surface fluxes that is
+                                ! available to drive entrainment at the base of mixed layer when that energy is
+                                ! positive.
 MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
-                                ! The efficiency with which mean kinetic energy released
-                                ! by mechanically forced entrainment of the mixed layer
-                                ! is converted to turbulent kinetic energy.
+                                ! The efficiency with which mean kinetic energy released by mechanically forced
+                                ! entrainment of the mixed layer is converted to turbulent kinetic energy.
 WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A ratio relating the efficiency with which convectively
-                                ! released energy is converted to a turbulent velocity,
-                                ! relative to mechanically forced TKE. Making this larger
-                                ! increases the BL diffusivity
+                                ! A ratio relating the efficiency with which convectively released energy is
+                                ! converted to a turbulent velocity, relative to mechanically forced TKE. Making
+                                ! this larger increases the BL diffusivity
 VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
-                                ! An overall nondimensional scaling factor for v*.
-                                ! Making this larger decreases the PBL diffusivity.
+                                ! An overall nondimensional scaling factor for v*. Making this larger decreases
+                                ! the PBL diffusivity.
 EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
-                                ! A nondimensional scaling factor controlling the inhibition
-                                ! of the diffusive length scale by rotation. Making this larger
-                                ! decreases the PBL diffusivity.
+                                ! A nondimensional scaling factor controlling the inhibition of the diffusive
+                                ! length scale by rotation. Making this larger decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turbulent boundary
-                                ! layer to help set the EPBL length scale.
+                                ! A logical that specifies whether or not to use the distance to the bottom of
+                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
-                                ! A logical that specifies whether or not to use the
-                                ! old method for determining MLD depth in iteration, which
-                                ! is limited to resolution.
+                                ! A logical that specifies whether or not to use the old method for determining
+                                ! MLD depth in iteration, which is limited to resolution.
 MLD_ITERATION_GUESS = False     !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the
-                                ! previous timestep MLD as a first guess in the MLD iteration.
-                                ! The default is false to facilitate reproducibility.
+                                ! A logical that specifies whether or not to use the previous timestep MLD as a
+                                ! first guess in the MLD iteration. The default is false to facilitate
+                                ! reproducibility.
 EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
-                                ! The tolerance for the iteratively determined mixed
-                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
-                                ! The minimum mixing length scale that will be used
-                                ! by ePBL.  The default (0) does not set a minimum.
+                                ! The minimum mixing length scale that will be used by ePBL.  The default (0)
+                                ! does not set a minimum.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
-                                ! If true, the ePBL code uses the original form of the
-                                ! potential energy change code.  Otherwise, the newer
-                                ! version that can work with successive increments to the
-                                ! diffusivity in upward or downward passes is used.
+                                ! If true, the ePBL code uses the original form of the potential energy change
+                                ! code.  Otherwise, the newer version that can work with successive increments
+                                ! to the diffusivity in upward or downward passes is used.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
-                                ! A scale for the mixing length in the transition layer
-                                ! at the edge of the boundary layer as a fraction of the
-                                ! boundary layer thickness.  The default is 0.1.
+                                ! A scale for the mixing length in the transition layer at the edge of the
+                                ! boundary layer as a fraction of the boundary layer thickness.  The default is
+                                ! 0.1.
 N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is positive.  The default is 0, but should probably be ~0.4.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is positive.  The default is 0, but
+                                ! should probably be ~0.4.
 N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
-                                ! A scale for the dissipation of TKE due to stratification
-                                ! in the boundary layer, applied when local stratification
-                                ! is negative.  The default is 0, but should probably be ~1.
+                                ! A scale for the dissipation of TKE due to stratification in the boundary
+                                ! layer, applied when local stratification is negative.  The default is 0, but
+                                ! should probably be ~1.
 USE_LA_LI2016 = False           !   [nondim] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to
-                                !  determine the Langmuir number.
+                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
+                                ! Langmuir number.
 EPBL_LT = False                 !   [nondim] default = False
                                 ! A logical to use a LT parameterization.
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1499,91 +1342,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1591,11 +1425,9 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1603,48 +1435,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1652,12 +1477,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.layout
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -7,43 +7,36 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -59,16 +52,16 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1.0                    !   [degrees]
@@ -105,8 +98,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -114,8 +107,7 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
@@ -145,9 +137,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -156,8 +147,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -182,25 +172,20 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
@@ -212,62 +197,54 @@ Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -276,25 +253,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -304,26 +278,24 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = True                  !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
@@ -337,42 +309,39 @@ PASSIVE = True                  !   [Boolean] default = False
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -383,30 +352,27 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_energetic_PBL ===
 EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
-                                ! The (tiny) minimum friction velocity used within the
-                                ! ePBL code, derived from OMEGA and ANGSTROM.
+                                ! The (tiny) minimum friction velocity used within the ePBL code, derived from
+                                ! OMEGA and ANGSTROM.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -421,58 +387,48 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -9,142 +9,120 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -152,16 +130,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -171,17 +147,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 75                         !   [nondim]
                                 ! The number of model layers.
 
@@ -191,8 +165,8 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -204,13 +178,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -247,13 +221,13 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -272,60 +246,53 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -345,8 +312,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -376,13 +343,12 @@ COORD_CONFIG = "none"           !
 GFS = 9.8                       !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -393,8 +359,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -414,46 +379,40 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PLM"        ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -464,48 +423,40 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 TEMP_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "WOA_column.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures, only.
+                                ! The name of the z-space input file used to initialize temperatures, only.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
-                                ! is True.
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
 Z_INIT_REMAP_GENERAL = False    !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
+                                ! If false, only initializes to z* coordinates. If true, allows initialization
+                                ! directly to general coordinates.
 Z_INIT_REMAP_FULL_COLUMN = False !   [Boolean] default = False
-                                ! If false, only reconstructs profiles for valid data points.
-                                ! If true, inserts vanished layers below the valid data.
+                                ! If false, only reconstructs profiles for valid data points. If true, inserts
+                                ! vanished layers below the valid data.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
-                                ! If false, uses the preferred remapping algorithm for initialization.
-                                ! If true, use an older, less robust algorithm for remapping.
+                                ! If false, uses the preferred remapping algorithm for initialization. If true,
+                                ! use an older, less robust algorithm for remapping.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -515,45 +466,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -569,113 +517,98 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -685,82 +618,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -768,116 +689,99 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -889,123 +793,111 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 2.0E-06             !   [m2 s-1] default = 2.0E-06
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars.
-                                ! If False, calculates the non-local transport and tendencies but
-                                ! purely for diagnostic purposes.
+                                ! If True, applies the non-local transport to heat and scalars. If False,
+                                ! calculates the non-local transport and tendencies but purely for diagnostic
+                                ! purposes.
 N_SMOOTH = 0                    ! default = 0
-                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on
-                                ! OBL depth.
+                                ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.3                   !   [nondim] default = 0.3
-                                ! Critical bulk Richardson number used to define depth of the
-                                ! surface Ocean Boundary Layer (OBL).
+                                ! Critical bulk Richardson number used to define depth of the surface Ocean
+                                ! Boundary Layer (OBL).
 VON_KARMAN = 0.4                !   [nondim] default = 0.4
                                 ! von Karman constant.
 ENHANCE_DIFFUSION = True        !   [Boolean] default = True
@@ -1019,28 +911,25 @@ INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
-                                ! If True, limit the OBL depth to be no deeper than
-                                ! Monin-Obukhov depth.
+                                ! If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
 CS = 98.96                      !   [nondim] default = 98.96
                                 ! Parameter for computing velocity scale function.
 CS2 = 6.32739901508             !   [nondim] default = 6.32739901508
                                 ! Parameter for computing non-local term.
 DEEP_OBL_OFFSET = 0.0           !   [m] default = 0.0
-                                ! If non-zero, the distance above the bottom to which the OBL is clipped
-                                ! if it would otherwise reach the bottom. The smaller of this and 0.1D is used.
+                                ! If non-zero, the distance above the bottom to which the OBL is clipped if it
+                                ! would otherwise reach the bottom. The smaller of this and 0.1D is used.
 FIXED_OBLDEPTH = False          !   [Boolean] default = False
-                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE
-                                ! rather than using the OBL depth from CVMix.
-                                ! This option is just for testing purposes.
+                                ! If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE rather than using the OBL
+                                ! depth from CVMix. This option is just for testing purposes.
 FIXED_OBLDEPTH_VALUE = 30.0     !   [m] default = 30.0
-                                ! Value for the fixed OBL depth when fixedOBLdepth==True.
-                                ! This parameter is for just for testing purposes.
-                                ! It will over-ride the OBLdepth computed from CVMix.
+                                ! Value for the fixed OBL depth when fixedOBLdepth==True. This parameter is for
+                                ! just for testing purposes. It will over-ride the OBLdepth computed from CVMix.
 SURF_LAYER_EXTENT = 0.1         !   [nondim] default = 0.1
                                 ! Fraction of OBL depth considered in the surface layer.
 MINIMUM_OBL_DEPTH = 0.0         !   [m] default = 0.0
-                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of
-                                ! this parameter, the OBL depth is always at least as deep as the first layer.
+                                ! If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+                                ! parameter, the OBL depth is always at least as deep as the first layer.
 MINIMUM_VT2 = 1.0E-10           !   [m2/s2] default = 1.0E-10
                                 ! Min of the unresolved velocity Vt2 used in Rib CVMix calculation.
                                 ! Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.
@@ -1048,21 +937,21 @@ CORRECT_SURFACE_LAYER_AVERAGE = False !   [Boolean] default = False
                                 ! If true, applies a correction step to the averaging of surface layer
                                 ! properties. This option is obsolete.
 FIRST_GUESS_SURFACE_LAYER_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The first guess at the depth of the surface layer used for averaging
-                                ! the surface layer properties. If =0, the top model level properties
-                                ! will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a
-                                ! subsequent correction is applied. This parameter is obsolete
+                                ! The first guess at the depth of the surface layer used for averaging the
+                                ! surface layer properties. If =0, the top model level properties will be used
+                                ! for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a subsequent
+                                ! correction is applied. This parameter is obsolete
 NLT_SHAPE = "PARABOLIC"         ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
 MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
-                                ! CVMix method to set profile function for diffusivity and NLT,
-                                ! as well as matching across OBL base. Allowed values are:
+                                ! CVMix method to set profile function for diffusivity and NLT, as well as
+                                ! matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
                                 !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
                                 !      matching
@@ -1074,15 +963,15 @@ KPP_IS_ADDITIVE = True          !   [Boolean] default = True
                                 ! If true, adds KPP diffusivity to diffusivity from other schemes.
                                 ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface
-                                ! buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.
+                                ! Options include:
                                 !   ALL_SW: use total shortwave radiation
                                 !   MXL_SW: use shortwave radiation absorbed by mixing layer
                                 !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
-                                ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
-                                ! of MOM.
+                                ! A minimum thickness used to avoid division by small numbers in the vicinity of
+                                ! vanished layers. This is independent of MIN_THICKNESS used in other parts of
+                                ! MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1091,291 +980,255 @@ USE_KPP_LT_VT2 = False          ! default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
 %KPP
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = True          !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 ML_RAD_EFOLD_COEFF = 0.2        !   [nondim] default = 0.2
-                                ! A coefficient that is used to scale the penetration
-                                ! depth for turbulence below the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! A coefficient that is used to scale the penetration depth for turbulence below
+                                ! the base of the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_KD_MAX = 0.001           !   [m2 s-1] default = 0.001
-                                ! The maximum diapycnal diffusivity due to turbulence
-                                ! radiated from the base of the mixed layer.
-                                ! This is only used if ML_RADIATION is true.
+                                ! The maximum diapycnal diffusivity due to turbulence radiated from the base of
+                                ! the mixed layer. This is only used if ML_RADIATION is true.
 ML_RAD_COEFF = 0.2              !   [nondim] default = 0.2
-                                ! The coefficient which scales MSTAR*USTAR^3 to obtain
-                                ! the energy available for mixing below the base of the
-                                ! mixed layer. This is only used if ML_RADIATION is true.
+                                ! The coefficient which scales MSTAR*USTAR^3 to obtain the energy available for
+                                ! mixing below the base of the mixed layer. This is only used if ML_RADIATION is
+                                ! true.
 ML_RAD_APPLY_TKE_DECAY = True   !   [Boolean] default = True
-                                ! If true, apply the same exponential decay to ML_rad as
-                                ! is applied to the other surface sources of TKE in the
-                                ! mixed layer code. This is only used if ML_RADIATION is true.
+                                ! If true, apply the same exponential decay to ML_rad as is applied to the other
+                                ! surface sources of TKE in the mixed layer code. This is only used if
+                                ! ML_RADIATION is true.
 MSTAR = 1.2                     !   [units=nondim] default = 1.2
-                                ! The ratio of the friction velocity cubed to the TKE
-                                ! input to the mixed layer.
+                                ! The ratio of the friction velocity cubed to the TKE input to the mixed layer.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 KDML = 2.0E-05                  !   [m2 s-1] default = 2.0E-05
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
-                                ! This character string specifies how chlorophyll
-                                ! concentrations are translated into opacities. Currently
-                                ! valid options include:
+                                ! This character string specifies how chlorophyll concentrations are translated
+                                ! into opacities. Currently valid options include:
                                 !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
                                 !        MOREL_88 - Use Morel, JGR, 1988.
 CHL_FROM_FILE = True            !   [Boolean] default = True
                                 ! If true, chl_a is read from a file.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "CHL_A"           ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
 BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
-                                ! The fraction of the penetrating shortwave radiation
-                                ! that is in the blue band.
+                                ! The fraction of the penetrating shortwave radiation that is in the blue band.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1392,91 +1245,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1484,11 +1328,9 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1496,48 +1338,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1545,12 +1380,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.debugging
@@ -7,50 +7,44 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.layout
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 2                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -7,43 +7,36 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -59,16 +52,16 @@ INPUTDIR = "INPUT/BATS"         ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 30.0                 !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1.0                    !   [degrees]
@@ -105,8 +98,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -114,8 +107,7 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 7.59943E-05               !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 
 ! === module MOM_tracer_registry ===
 
@@ -145,9 +137,8 @@ COORD_CONFIG = "none"           !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -156,8 +147,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -182,25 +172,20 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
 TEMP_SALT_Z_INIT_FILE = "WOA_column.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize
-                                ! temperatures (T) and salinities (S). If T and S are not
-                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
-                                ! must be set.
+                                ! The name of the z-space input file used to initialize temperatures (T) and
+                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
+                                ! SALT_Z_INIT_FILE must be set.
 Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
-                                ! The name of the potential temperature variable in
-                                ! TEMP_Z_INIT_FILE.
+                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
-                                ! The name of the salinity variable in
-                                ! SALT_Z_INIT_FILE.
+                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
 Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated
-                                ! initial conditions.
+                                ! If True, then horizontally homogenize the interpolated initial conditions.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 
@@ -212,62 +197,54 @@ Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -276,25 +253,22 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HARMONIC_VISC = True            !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HMIX_FIXED = 0.01               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
@@ -304,12 +278,11 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 !NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
+                                ! The number of depth-space levels.  This is determined from the size of the
+                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -318,15 +291,15 @@ Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = True                  !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
 NLT_SHAPE = "PARABOLIC"         ! default = "CVMix"
-                                ! MOM6 method to set nonlocal transport profile.
-                                ! Over-rides the result from CVMix.  Allowed values are:
+                                ! MOM6 method to set nonlocal transport profile. Over-rides the result from
+                                ! CVMix.  Allowed values are:
                                 !    CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE
                                 !    LINEAR    - A linear profile, 1-sigma
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
@@ -342,42 +315,39 @@ NLT_SHAPE = "PARABOLIC"         ! default = "CVMix"
 
 ! === module MOM_entrain_diffusive ===
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 2.683281572999748E-05
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 ML_RADIATION = True             !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 TKE_DECAY = 10.0                !   [nondim] default = 2.5
                                 ! The ratio of the natural Ekman depth to the TKE decay scale.
 ML_OMEGA_FRAC = 1.0             !   [nondim] default = 0.0
-                                ! When setting the decay scale for turbulence, use this
-                                ! fraction of the absolute rotation rate blended with the
-                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                                ! When setting the decay scale for turbulence, use this fraction of the absolute
+                                ! rotation rate blended with the local value of f, as sqrt((1-of)*f^2 +
+                                ! of*4*omega^2).
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 2.0E-05                    !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 2.0E-07
                                 ! The minimum diapycnal diffusivity.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = True        !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 MAX_RINO_IT = 25                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
@@ -388,25 +358,22 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = False          !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 
 ! === module MOM_regularize_layers ===
 HMIX_MIN = 2.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = True               !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 CHL_FILE = "forcing_monthly.nc" !
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+                                ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 PEN_SW_NBANDS = 3               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 
@@ -421,58 +388,48 @@ KHTR = 600.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 10.0           !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "data_override"   !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "data_override"   !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 READ_GUST_2D = True             !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_2D_FILE = "forcing_monthly.nc" !
-                                ! The file in which the wind gustiness is found in
-                                ! variable gustiness.
+                                ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 180.0                  !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 0             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 3650.0                !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,19 +221,19 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -279,71 +252,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -363,8 +326,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -392,11 +355,9 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -405,12 +366,11 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -438,13 +398,13 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
-                                ! Initial amplitude of sloshing internal interface height
-                                ! displacements it the sloshing test case.
+                                ! Initial amplitude of sloshing internal interface height displacements it the
+                                ! sloshing test case.
 SLOSHING_IC_BUG = True          !   [Boolean] default = True
                                 ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -471,8 +431,8 @@ S_RANGE = 2.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -482,41 +442,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -532,113 +489,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -646,106 +588,89 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -753,50 +678,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -806,162 +725,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -971,53 +863,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1027,363 +910,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1400,91 +1240,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1492,8 +1323,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1501,48 +1331,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1550,12 +1373,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.layout
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -5,37 +5,30 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -51,8 +44,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -64,8 +57,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -99,14 +92,14 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -118,17 +111,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -155,8 +145,7 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 
@@ -165,8 +154,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -194,8 +183,8 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -226,62 +215,54 @@ T_REF = 0.0                     !   [C]
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -292,47 +273,40 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -342,20 +316,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -380,22 +351,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -413,11 +381,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -428,9 +395,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -439,49 +405,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,19 +221,19 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -279,71 +252,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -363,8 +326,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -392,21 +355,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -417,12 +377,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -433,14 +391,11 @@ INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -462,12 +417,10 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1034.0, 1034.2, 1034.4, 1034.6000000000001, 1034.8000000000002, 1035.0000000000002, 1035.2000000000003, 1035.4000000000003, 1035.6000000000004, 1035.8000000000004, 1036.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "NONE" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -487,43 +440,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -534,12 +482,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -567,13 +514,13 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
-                                ! Initial amplitude of sloshing internal interface height
-                                ! displacements it the sloshing test case.
+                                ! Initial amplitude of sloshing internal interface height displacements it the
+                                ! sloshing test case.
 SLOSHING_IC_BUG = True          !   [Boolean] default = True
                                 ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -600,8 +547,8 @@ S_RANGE = 2.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -611,45 +558,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -665,113 +609,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -779,106 +708,89 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -886,50 +798,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -939,162 +845,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1104,53 +983,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1160,363 +1030,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1533,91 +1360,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1625,8 +1443,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1634,48 +1451,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1683,12 +1493,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.layout
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -5,33 +5,28 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -47,8 +42,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -60,8 +55,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -95,14 +90,14 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -114,17 +109,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -151,14 +143,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -167,12 +157,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -183,11 +171,9 @@ INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 !ALE_RESOLUTION = 10*0.2        !   [kg m^-3]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
@@ -197,10 +183,9 @@ BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
 !TARGET_DENSITIES = 1034.0, 1034.2, 1034.4, 1034.6000000000001, 1034.8000000000002, 1035.0000000000002, 1035.2000000000003, 1035.4000000000003, 1035.6000000000004, 1035.8000000000004, 1036.0 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -212,8 +197,8 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -241,8 +226,8 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -273,62 +258,54 @@ T_REF = 0.0                     !   [C]
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -339,47 +316,40 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -389,20 +359,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -427,22 +394,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -460,11 +424,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -475,9 +438,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -486,49 +448,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 900.0                !   [s] default = 900.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 2                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -248,19 +221,19 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -279,71 +252,61 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -363,8 +326,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -392,21 +355,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -417,8 +377,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -438,46 +397,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -488,12 +441,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -521,13 +473,13 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
-                                ! Initial amplitude of sloshing internal interface height
-                                ! displacements it the sloshing test case.
+                                ! Initial amplitude of sloshing internal interface height displacements it the
+                                ! sloshing test case.
 SLOSHING_IC_BUG = True          !   [Boolean] default = True
                                 ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -554,8 +506,8 @@ S_RANGE = 2.0                   !   [1e-3] default = 2.0
 T_RANGE = 0.0                   !   [C] default = 0.0
                                 ! Initial temperature range
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -565,45 +517,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -619,113 +568,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 10.0               !   [m] default = 10.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
@@ -733,106 +667,89 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -840,50 +757,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -893,162 +804,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1058,53 +942,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -1114,363 +989,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-08         !   [m] default = 1.0E-08
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1487,91 +1319,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1579,8 +1402,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1588,48 +1410,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1637,12 +1452,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/sloshing/z/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/sloshing/z/MOM_parameter_doc.layout
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 3                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -5,33 +5,28 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 900.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
                                 ! If true, the domain is zonally reentrant.
 NIGLOBAL = 40                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 2                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -47,8 +42,8 @@ INPUTDIR = "INPUT/"             ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -60,8 +55,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 20.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -95,14 +90,14 @@ TOPO_CONFIG = "sloshing"        !
 MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
-                                ! If MASKING_DEPTH is unspecified, then anything shallower than
-                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
-                                ! If MASKING_DEPTH is specified, then all depths shallower than
-                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
+                                ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
+                                ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
+                                ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -114,17 +109,14 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -151,14 +143,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.0       !   [kg m-3] default = 1035.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 GFS = 0.98                      !   [m s-2] default = 9.8
                                 ! The reduced gravity at the free surface.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -173,10 +163,9 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -188,8 +177,8 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "sloshing"   !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -217,8 +206,8 @@ THICKNESS_CONFIG = "sloshing"   !
 
 ! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -249,62 +238,54 @@ T_REF = 0.0                     !   [C]
 
 ! === module MOM_set_visc ===
 LINEAR_DRAG = True              !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 0.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 BE = 0.7                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.0E-10
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option is
-                                ! always effectively false with CORIOLIS_EN_DIS defined and
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option is always effectively false with CORIOLIS_EN_DIS defined and
                                 ! CORIOLIS_SCHEME set to SADOURNY75_ENERGY.
 
 ! === module MOM_PressureForce ===
@@ -315,47 +296,40 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 20.0               !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -365,20 +339,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 10.0                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
@@ -403,22 +374,19 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -436,11 +404,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -451,9 +418,8 @@ PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
@@ -462,49 +428,41 @@ DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 5.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 9.9999E+04            !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 48                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 48                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 48                   !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 0.0                  !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 5                          !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 172.8                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 172.8                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 200.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 0.8                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = True !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -379,18 +342,15 @@ ADVECTION_TEST_X_WIDTH = 21.6   !   [not defined] default = 0.0
 ADVECTION_TEST_Y_WIDTH = 21.6   !   [not defined] default = 0.0
                                 ! The y-width of the test-functions.
 ADVECTION_TEST_TRACER_IC_FILE = "" ! default = ""
-                                ! The name of a file from which to read the initial
-                                ! conditions for the tracers, or blank to initialize
-                                ! them internally.
+                                ! The name of a file from which to read the initial conditions for the tracers,
+                                ! or blank to initialize them internally.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified from MOM_initialization.F90.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified from MOM_initialization.F90.
 TRACERS_MAY_REINIT = False      !   [Boolean] default = False
-                                ! If true, tracers may go through the initialization code
-                                ! if they are not found in the restart files.  Otherwise
-                                ! it is a fatal error if the tracers are not found in the
-                                ! restart files of a restarted run.
+                                ! If true, tracers may go through the initialization code if they are not found
+                                ! in the restart files.  Otherwise it is a fatal error if the tracers are not
+                                ! found in the restart files of a restarted run.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "ts_ref"         !
@@ -425,12 +385,11 @@ GINT = 7.89E-04                 !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -456,8 +415,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -476,11 +435,11 @@ TS_CONFIG = "fit"               !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 FIT_SALINITY = False            !   [Boolean] default = False
-                                ! If true, accept the prescribed temperature and fit the
-                                ! salinity; otherwise take salinity and fit temperature.
+                                ! If true, accept the prescribed temperature and fit the salinity; otherwise
+                                ! take salinity and fit temperature.
 VELOCITY_CONFIG = "uniform"     ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -494,37 +453,35 @@ INITIAL_U_CONST = 0.2           !   [m s-1]
 INITIAL_V_CONST = 0.2           !   [m s-1]
                                 ! A initial uniform value for the meridional flow.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -540,99 +497,87 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = False           !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 1.0E-08                  !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 1.0E-08            !   [m] default = 1.0E-08
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
@@ -640,106 +585,89 @@ KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 0.0             !   [m] default = 0.0
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 0.0         !   [m] default = 0.0
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -747,50 +675,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -800,160 +722,136 @@ KH = 0.01                       !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = False         !   [Boolean] default = False
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 KVBBL = 0.0                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the benthic boundary layer.
-                                ! A typical value is ~1e-2 m2 s-1. KVBBL is not used if
-                                ! BOTTOMDRAGLAW is true.  The default is set by KV.
+                                ! The kinematic viscosity in the benthic boundary layer. A typical value is
+                                ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
+                                ! by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
-                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number
-                                ! of barotropic time steps between updates to the face
-                                ! areas, or 0 to update only before the barotropic stepping.
+                                ! If NONLINEAR_BT_CONTINUITY is true, this is the number of barotropic time
+                                ! steps between updates to the face areas, or 0 to update only before the
+                                ! barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -963,53 +861,44 @@ BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 10.0                !   [m] default = 10.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1019,346 +908,306 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 0.0
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 0.0              !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.0               !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1375,91 +1224,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1467,8 +1307,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1476,48 +1315,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 2.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 100.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1525,12 +1357,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.debugging
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.layout
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 2                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 2                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -5,31 +5,25 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -37,13 +31,11 @@ IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 48                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 48                   !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -51,10 +43,9 @@ NJGLOBAL = 48                   !
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 0.0                  !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 5                          !   [nondim]
@@ -66,8 +57,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -79,8 +70,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 172.8                  !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 172.8                  !   [k]
@@ -117,8 +108,8 @@ MAXIMUM_DEPTH = 200.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -130,10 +121,9 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 
 ! === module MOM_restart ===
 
@@ -180,8 +170,8 @@ GINT = 7.89E-04                 !   [m s-2]
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -207,8 +197,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "fit"               !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -227,8 +217,8 @@ TS_CONFIG = "fit"               !
                                 !     SCM_CVMix_tests - used in the SCM CVMix tests.
                                 !     USER - call a user modified routine.
 VELOCITY_CONFIG = "uniform"     ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -250,25 +240,21 @@ INITIAL_V_CONST = 0.2           !   [m s-1]
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = False           !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 HBBL = 1.0E-08                  !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 BBL_THICK_MIN = 0.1             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-04                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 
@@ -278,14 +264,13 @@ KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -298,59 +283,49 @@ LAPLACIAN = True                !   [Boolean] default = False
 KH = 0.01                       !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 BOUND_KH = False                !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVBBL = 0.0                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the benthic boundary layer.
-                                ! A typical value is ~1e-2 m2 s-1. KVBBL is not used if
-                                ! BOTTOMDRAGLAW is true.  The default is set by KV.
+                                ! The kinematic viscosity in the benthic boundary layer. A typical value is
+                                ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
+                                ! by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = -0.9                     !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -373,12 +348,11 @@ DTBT = -0.9                     !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 20                 ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-05         !   [m] default = 0.0
                                 ! The tolerance with which to solve for entrainment values.
 
@@ -387,9 +361,8 @@ TOLERANCE_ENT = 1.0E-05         !   [m] default = 0.0
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -416,59 +389,51 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 DATE_STAMPED_STDOUT = False     !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 2.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = -1            ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 100.0                 !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.5       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 10.0                      !   [m s-2] default = 10.0
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,12 +374,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
                                 ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -430,14 +388,11 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -459,12 +414,10 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
 !TARGET_DENSITIES = 1034.5, 1034.6, 1034.6999999999998, 1034.7999999999997, 1034.8999999999996, 1034.9999999999995, 1035.0999999999995, 1035.1999999999994, 1035.2999999999993, 1035.3999999999992, 1035.5 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
-                                ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogeneous
-                                ! regions appear stratified.
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 MAXIMUM_INT_DEPTH_CONFIG = "NONE" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -484,43 +437,38 @@ MAX_LAYER_THICKNESS_CONFIG = "NONE" ! default = "NONE"
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
                                 !  FNC1:string - FNC1:dz_min,H_total,power,precision
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -531,12 +479,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -562,8 +509,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "baroclinic_zone"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -605,8 +552,8 @@ L_ZONE = 100.0                  !   [kilometers] default = 20.0
                                 ! Width of baroclinic zone
 %BCZIC
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -616,45 +563,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -670,113 +614,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.01           !   [m] default = 0.01
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
@@ -784,106 +713,89 @@ KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.000000000000001E-15
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -891,50 +803,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -944,162 +850,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 1.0E-10           !   [m] default = 1.0E-10
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1109,53 +988,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 5.0                 !   [m] default = 5.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1165,363 +1035,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-13         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1538,101 +1365,90 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 5.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1640,8 +1456,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1649,48 +1464,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 0.0                   !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1698,12 +1506,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.layout
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
@@ -5,21 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -29,13 +26,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -45,10 +40,9 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 10                         !   [nondim]
@@ -60,8 +54,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -73,8 +67,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -111,8 +105,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -124,17 +118,14 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -161,15 +152,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.5       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -178,12 +166,10 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
-                                ! This sets the interpolation scheme to use to
-                                ! determine the new grid. These parameters are
-                                ! only relevant when REGRIDDING_COORDINATE_MODE is
-                                ! set to a function of state. Otherwise, it is not
-                                ! used. It can be one of the following schemes:
-                                !  P1M_H2     (2nd-order accurate)
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:  P1M_H2     (2nd-order accurate)
                                 !  P1M_H4     (2nd-order accurate)
                                 !  P1M_IH4    (2nd-order accurate)
                                 !  PLM        (2nd-order accurate)
@@ -194,11 +180,9 @@ INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 !  PQM_IH4IH3 (4th-order accurate)
                                 !  PQM_IH6IH5 (5th-order accurate)
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
-                                ! When defined, a proper high-order reconstruction
-                                ! scheme is used within boundary cells rather
-                                ! than PCM. E.g., if PPM is used for remapping, a
-                                ! PPM reconstruction will also be used within
-                                ! boundary cells.
+                                ! When defined, a proper high-order reconstruction scheme is used within
+                                ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
+                                ! reconstruction will also be used within boundary cells.
 !ALE_RESOLUTION = 10*0.1        !   [kg m^-3]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
@@ -208,13 +192,11 @@ BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
 !TARGET_DENSITIES = 1034.5, 1034.6, 1034.6999999999998, 1034.7999999999997, 1034.8999999999996, 1034.9999999999995, 1035.0999999999995, 1035.1999999999994, 1035.2999999999993, 1035.3999999999992, 1035.5 !   [kg m^-3]
                                 ! RHO target densities for interfaces
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -226,8 +208,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -253,8 +235,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "baroclinic_zone"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -296,45 +278,40 @@ L_ZONE = 100.0                  !   [kilometers] default = 20.0
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.000000000000001E-15
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -347,48 +324,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -398,20 +367,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -434,22 +400,19 @@ DTBT = 5.0                      !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -467,11 +430,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -486,53 +448,46 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 5.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
@@ -7,148 +7,125 @@
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = True                  !   [Boolean] default = True
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = False               !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 3600.0               !   [s] default = 3600.0
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = -1.0
-                                ! The period between recalculations of DTBT (if DTBT <= 0).
-                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
-                                ! only on information available at initialization.  If 0,
-                                ! DTBT will be set every dynamics time step. The default
+                                ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
+                                ! is negative, DTBT is set based only on information available at
+                                ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
 FRAZIL = False                  !   [Boolean] default = False
-                                ! If true, water freezes if it gets too cold, and the
-                                ! the accumulated heat deficit is returned in the
-                                ! surface state.  FRAZIL is only used if
+                                ! If true, water freezes if it gets too cold, and the the accumulated heat
+                                ! deficit is returned in the surface state.  FRAZIL is only used if
                                 ! ENABLE_THERMODYNAMICS is true.
 DO_GEOTHERMAL = False           !   [Boolean] default = False
                                 ! If true, apply geothermal heating.
 BOUND_SALINITY = False          !   [Boolean] default = False
-                                ! If true, limit salinity to being positive. (The sea-ice
-                                ! model may ask for more salt than is available and
-                                ! drive the salinity negative otherwise.)
+                                ! If true, limit salinity to being positive. (The sea-ice model may ask for more
+                                ! salt than is available and drive the salinity negative otherwise.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
-                                ! The pressure that is used for calculating the coordinate
-                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
-                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
-                                ! are true.
+                                ! The pressure that is used for calculating the coordinate density.  (1 Pa = 1e4
+                                ! dbar, so 2e7 is commonly used.) This is only used if USE_EOS and
+                                ! ENABLE_THERMODYNAMICS are true.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -156,16 +133,14 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -175,17 +150,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -195,8 +168,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -208,13 +181,13 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [k] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 200.0                  !   [k]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -251,13 +224,13 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -276,71 +249,61 @@ ROTATION = "beta"               ! default = "2omegasinlat"
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
 F_0 = 0.0                       !   [s-1] default = 0.0
-                                ! The reference value of the Coriolis parameter with the
-                                ! betaplane option.
+                                ! The reference value of the Coriolis parameter with the betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
-                                ! The northward gradient of the Coriolis parameter with
-                                ! the betaplane option.
+                                ! The northward gradient of the Coriolis parameter with the betaplane option.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the density at T=0, S=0.
+                                ! When EQN_OF_STATE=LINEAR, this is the density at T=0, S=0.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 EOS_QUADRATURE = False          !   [Boolean] default = False
-                                ! If true, always use the generic (quadrature) code
-                                ! code for the integrals of density.
+                                ! If true, always use the generic (quadrature) code code for the integrals of
+                                ! density.
 TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
-                                ! TFREEZE_FORM determines which expression should be
-                                ! used for the freezing point.  Currently, the valid
-                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+                                ! TFREEZE_FORM determines which expression should be used for the freezing
+                                ! point.  Currently, the valid choices are "LINEAR", "MILLERO_78", "TEOS10"
 TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the freezing potential temperature at
-                                ! S=0, P=0.
+                                ! When TFREEZE_FORM=LINEAR, this is the freezing potential temperature at S=0,
+                                ! P=0.
 DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with salinity.
 DTFREEZE_DP = 0.0               !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
+                                ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -360,8 +323,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -389,21 +352,18 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.5       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 GFS = 10.0                      !   [m s-2] default = 10.0
                                 ! The reduced gravity at the free surface.
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
-                                ! If true, uses the old remapping-via-a-delta-z method for
-                                ! remapping u and v. If false, uses the new method that remaps
-                                ! between grids described by an old and new thickness.
+                                ! If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+                                ! false, uses the new method that remaps between grids described by an old and
+                                ! new thickness.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -414,8 +374,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -435,46 +394,40 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
-                                ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicity or an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, cell-by-cell reconstructions are checked for consistency and if
+                                ! non-monotonicity or an inconsistency is detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
-                                ! If true, the results of remapping are checked for
-                                ! conservation and new extrema and if an inconsistency is
-                                ! detected then a FATAL error is issued.
+                                ! If true, the results of remapping are checked for conservation and new extrema
+                                ! and if an inconsistency is detected then a FATAL error is issued.
 REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
-                                ! If true, the values on the intermediate grid used for remapping
-                                ! are forced to be bounded, which might not be the case due to
-                                ! round off.
+                                ! If true, the values on the intermediate grid used for remapping are forced to
+                                ! be bounded, which might not be the case due to round off.
 REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
-                                ! If true, values at the interfaces of boundary cells are
-                                ! extrapolated instead of piecewise constant
+                                ! If true, values at the interfaces of boundary cells are extrapolated instead
+                                ! of piecewise constant
 REMAP_AFTER_INITIALIZATION = True !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
+                                ! If true, applies regridding and remapping immediately after initialization so
+                                ! that the state is ALE consistent. This is a legacy step and should not be
+                                ! needed if the initialization is consistent with the coordinate mode.
 REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
-                                ! The time-scale used in blending between the current (old) grid
-                                ! and the target (new) grid. A short time-scale favors the target
-                                ! grid (0. or anything less than DT_THERM) has no memory of the old
-                                ! grid. A very long time-scale makes the model more Lagrangian.
+                                ! The time-scale used in blending between the current (old) grid and the target
+                                ! (new) grid. A short time-scale favors the target grid (0. or anything less
+                                ! than DT_THERM) has no memory of the old grid. A very long time-scale makes the
+                                ! model more Lagrangian.
 REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
-                                ! The depth above which no time-filtering is applied. Above this depth
-                                ! final grid exactly matches the target (new) grid.
+                                ! The depth above which no time-filtering is applied. Above this depth final
+                                ! grid exactly matches the target (new) grid.
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
@@ -485,12 +438,11 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -516,8 +468,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "baroclinic_zone"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -559,8 +511,8 @@ L_ZONE = 100.0                  !   [kilometers] default = 20.0
                                 ! Width of baroclinic zone
 %BCZIC
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -570,45 +522,42 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
                                 ! algorithm to push the initial grid to be consistent with the initial
                                 ! condition. Useful only for state-based and iterative coordinates.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -624,113 +573,98 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt
-                                ! based on double-diffusive parameterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt based on
+                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
-                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
-                                ! LINEAR_DRAG) or an unresolved  velocity that is
-                                ! combined with the resolved velocity to estimate the
-                                ! velocity magnitude.  DRAG_BG_VEL is only used when
-                                ! BOTTOMDRAGLAW is defined.
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with LINEAR_DRAG) or an
+                                ! unresolved  velocity that is combined with the resolved velocity to estimate
+                                ! the velocity magnitude.  DRAG_BG_VEL is only used when BOTTOMDRAGLAW is
+                                ! defined.
 BBL_USE_EOS = False             !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the
-                                ! properties of the bottom boundary layer.  Otherwise use
-                                ! the layer target potential densities.
+                                ! If true, use the equation of state in determining the properties of the bottom
+                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.01           !   [m] default = 0.01
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 0.001              !   [m] default = 0.001
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
@@ -738,106 +672,89 @@ KV_TBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-06
 TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
-                                ! If SPLIT is true, BE determines the relative weighting
-                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
-                                ! scheme (0.5) and a backward Euler scheme (1) that is
-                                ! used for the Coriolis and inertial terms.  BE may be
-                                ! from 0.5 to 1, but instability may occur near 0.5.
-                                ! BE is also applicable if SPLIT is false and USE_RK2
-                                ! is true.
+                                ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
+                                ! Runga-Kutta baroclinic time stepping scheme (0.5) and a backward Euler scheme
+                                ! (1) that is used for the Coriolis and inertial terms.  BE may be from 0.5 to
+                                ! 1, but instability may occur near 0.5. BE is also applicable if SPLIT is false
+                                ! and USE_RK2 is true.
 BEGW = 0.0                      !   [nondim] default = 0.0
-                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
-                                ! controls the extent to which the treatment of gravity
-                                ! waves is forward-backward (0) or simulated backward
-                                ! Euler (1).  0 is almost always used.
-                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
-                                ! between 0 and 0.5 to damp gravity waves.
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that controls the extent to
+                                ! which the treatment of gravity waves is forward-backward (0) or simulated
+                                ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
+                                ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
-                                ! If true, provide the bottom stress calculated by the
-                                ! vertical viscosity to the barotropic solver.
+                                ! If true, provide the bottom stress calculated by the vertical viscosity to the
+                                ! barotropic solver.
 BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
-                                ! If true, use the summed layered fluxes plus an
-                                ! adjustment due to the change in the barotropic velocity
-                                ! in the barotropic continuity equation.
+                                ! If true, use the summed layered fluxes plus an adjustment due to the change in
+                                ! the barotropic velocity in the barotropic continuity equation.
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.000000000000001E-15
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 1.0E-12     !   [m] default = 1.0E-12
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -845,50 +762,44 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
@@ -898,162 +809,135 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
 KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the grid
-                                ! spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
+                                ! The velocity scale which is multiplied by the grid spacing to calculate the
+                                ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latitudinally-dependent background
-                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+                                ! The amplitude of a latitudinally-dependent background viscosity of the form
+                                ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 MODIFIED_LEITH = False          !   [Boolean] default = False
-                                ! If true, add a term to Leith viscosity which is
-                                ! proportional to the gradient of divergence.
+                                ! If true, add a term to Leith viscosity which is proportional to the gradient
+                                ! of divergence.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
                                 ! If true, the viscosity contribution from MEKE is scaled by the resolution
                                 ! function.
 BOUND_KH = True                 !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the Laplacian coefficient is locally limited to be stable.
 BETTER_BOUND_KH = True          !   [Boolean] default = True
-                                ! If true, the Laplacian coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_KH.
+                                ! If true, the Laplacian coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_KH.
 ANISOTROPIC_VISCOSITY = False   !   [Boolean] default = False
-                                ! If true, allow anistropic viscosity in the Laplacian
-                                ! horizontal viscosity.
+                                ! If true, allow anistropic viscosity in the Laplacian horizontal viscosity.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 1.0E-10           !   [m] default = 1.0E-10
-                                ! The depth over which the wind stress is applied if
-                                ! DIRECT_STRESS is true.
+                                ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
-                                ! If true, and BOUND_BT_CORRECTION is true, use the
-                                ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocities
+                                ! If true, and BOUND_BT_CORRECTION is true, use the BT_cont_type variables to
+                                ! set limits determined by MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
-                                ! If true, adjust the curve fit to the BT_cont type
-                                ! that is used by the barotropic solver to match the
-                                ! transport about which the flow is being linearized.
+                                ! If true, adjust the curve fit to the BT_cont type that is used by the
+                                ! barotropic solver to match the transport about which the flow is being
+                                ! linearized.
 GRADUAL_BT_ICS = False          !   [Boolean] default = False
-                                ! If true, adjust the initial conditions for the
-                                ! barotropic solver to the values from the layered
-                                ! solution over a whole timestep instead of instantly.
-                                ! This is a decent approximation to the inclusion of
-                                ! sum(u dh_dt) while also correcting for truncation errors.
+                                ! If true, adjust the initial conditions for the barotropic solver to the values
+                                ! from the layered solution over a whole timestep instead of instantly. This is
+                                ! a decent approximation to the inclusion of sum(u dh_dt) while also correcting
+                                ! for truncation errors.
 BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
-                                ! If true, use the viscous remnants when estimating the
-                                ! barotropic velocities that were used to calculate uh0
-                                ! and vh0.  False is probably the better choice.
+                                ! If true, use the viscous remnants when estimating the barotropic velocities
+                                ! that were used to calculate uh0 and vh0.  False is probably the better choice.
 USE_BT_CONT_TYPE = True         !   [Boolean] default = True
-                                ! If true, use a structure with elements that describe
-                                ! effective face areas from the summed continuity solver
-                                ! as a function the barotropic flow in coupling between
-                                ! the barotropic and baroclinic flow.  This is only used
-                                ! if SPLIT is true.
+                                ! If true, use a structure with elements that describe effective face areas from
+                                ! the summed continuity solver as a function the barotropic flow in coupling
+                                ! between the barotropic and baroclinic flow.  This is only used if SPLIT is
+                                ! true.
 NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
-                                ! If true, use nonlinear transports in the barotropic
-                                ! continuity equation.  This does not apply if
-                                ! USE_BT_CONT_TYPE is true.
+                                ! If true, use nonlinear transports in the barotropic continuity equation.  This
+                                ! does not apply if USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 DYNAMIC_SURFACE_PRESSURE = False !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
+                                ! If true, add a dynamic pressure due to a viscous ice shelf, for instance.
 SADOURNY = True                 !   [Boolean] default = True
-                                ! If true, the Coriolis terms are discretized with the
-                                ! Sadourny (1975) energy conserving scheme, otherwise
-                                ! the Arakawa & Hsu scheme is used.  If the internal
-                                ! deformation radius is not resolved, the Sadourny scheme
-                                ! should probably be used.
+                                ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
+                                ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
+                                ! internal deformation radius is not resolved, the Sadourny scheme should
+                                ! probably be used.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -1063,53 +947,44 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BT_STRONG_DRAG = False          !   [Boolean] default = False
-                                ! If true, use a stronger estimate of the retarding
-                                ! effects of strong bottom drag, by making it implicit
-                                ! with the barotropic time-step instead of implicit with
-                                ! the baroclinic time-step and dividing by the number of
-                                ! barotropic steps.
+                                ! If true, use a stronger estimate of the retarding effects of strong bottom
+                                ! drag, by making it implicit with the barotropic time-step instead of implicit
+                                ! with the baroclinic time-step and dividing by the number of barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
-                                ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _v divided by the depth of
-                                ! the ocean.  This was introduced to facilitate tide modeling.
+                                ! If true, apply a linear drag to the barotropic velocities, using rates set by
+                                ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
+                                ! facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
-                                ! If true, limit any velocity components that exceed
-                                ! CFL_TRUNCATE.  This should only be used as a desperate
-                                ! debugging measure.
+                                ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
+                                ! only be used as a desperate debugging measure.
 MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
-                                ! The maximum permitted CFL number associated with the
-                                ! barotropic accelerations from the summed velocities
-                                ! times the time-derivatives of thicknesses.
+                                ! The maximum permitted CFL number associated with the barotropic accelerations
+                                ! from the summed velocities times the time-derivatives of thicknesses.
 DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
-                                ! A time-scale over which the barotropic mode solutions
-                                ! are filtered, in seconds if positive, or as a fraction
-                                ! of DT if negative. When used this can never be taken to
-                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+                                ! A time-scale over which the barotropic mode solutions are filtered, in seconds
+                                ! if positive, or as a fraction of DT if negative. When used this can never be
+                                ! taken to be longer than 2*dt.  Set this to 0 to apply no filtering.
 G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
                                 ! A nondimensional factor by which gtot is enhanced.
 SSH_EXTRA = 5.0                 !   [m] default = 5.0
-                                ! An estimate of how much higher SSH might get, for use
-                                ! in calculating the safe external wave speed. The
-                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+                                ! An estimate of how much higher SSH might get, for use in calculating the safe
+                                ! external wave speed. The default is the minimum of 10 m or 5% of
+                                ! MAXIMUM_DEPTH.
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 BT_USE_OLD_CORIOLIS_BRACKET_BUG = False !   [Boolean] default = False
-                                ! If True, use an order of operations that is not bitwise
-                                ! rotationally symmetric in the meridional Coriolis term of
-                                ! the barotropic solver.
+                                ! If True, use an order of operations that is not bitwise rotationally symmetric
+                                ! in the meridional Coriolis term of the barotropic solver.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -1119,363 +994,320 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
+                                ! If true, use an implied energetics planetary boundary layer scheme to
+                                ! determine the diffusivity and viscosity in the surface boundary layer.
 EPBL_IS_ADDITIVE = True         !   [Boolean] default = True
-                                ! If true, the diffusivity from ePBL is added to all
-                                ! other diffusivities. Otherwise, the larger of kappa-
-                                ! shear and ePBL diffusivities are used.
+                                ! If true, the diffusivity from ePBL is added to all other diffusivities.
+                                ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 INTERNAL_TIDES = False          !   [Boolean] default = False
-                                ! If true, use the code that advances a separate set of
-                                ! equations for the internal tide energy density.
+                                ! If true, use the code that advances a separate set of equations for the
+                                ! internal tide energy density.
 MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
-                                ! If true, the temperature and salinity of massless layers
-                                ! are kept consistent with their target densities.
-                                ! Otherwise the properties of massless layers evolve
-                                ! diffusively to match massive neighboring layers.
+                                ! If true, the temperature and salinity of massless layers are kept consistent
+                                ! with their target densities. Otherwise the properties of massless layers
+                                ! evolve diffusively to match massive neighboring layers.
 AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
-                                ! If true, the net incoming and outgoing fresh water fluxes are combined
-                                ! and applied as either incoming or outgoing depending on the sign of the net.
-                                ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the topmost non-vanished
-                                ! layers of the updated state.
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined and
+                                ! applied as either incoming or outgoing depending on the sign of the net. If
+                                ! false, the net incoming fresh water flux is added to the model and thereafter
+                                ! the net outgoing is removed from the topmost non-vanished layers of the
+                                ! updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
-                                ! If true, mix the passive tracers in massless layers at
-                                ! the bottom into the interior as though a diffusivity of
-                                ! KD_MIN_TR were operating.
+                                ! If true, mix the passive tracers in massless layers at the bottom into the
+                                ! interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A minimal diffusivity that should always be applied to
-                                ! tracers, especially in massless layers near the bottom.
-                                ! The default is 0.1*KD.
+                                ! A minimal diffusivity that should always be applied to tracers, especially in
+                                ! massless layers near the bottom. The default is 0.1*KD.
 KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
-                                ! A bottom boundary layer tracer diffusivity that will
-                                ! allow for explicitly specified bottom fluxes. The
-                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
-                                ! over the same distance.
+                                ! A bottom boundary layer tracer diffusivity that will allow for explicitly
+                                ! specified bottom fluxes. The entrainment at the bottom is at least
+                                ! sqrt(Kd_BBL_tr*dt) over the same distance.
 TRACER_TRIDIAG = False          !   [Boolean] default = False
                                 ! If true, use the passive tracer tridiagonal solver for T and S
 MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
-                                ! The smallest depth over which forcing can be applied. This
-                                ! only takes effect when near-surface layers become thin
-                                ! relative to this scale, in which case the forcing tendencies
-                                ! scaled down by distributing the forcing over this depth scale.
+                                ! The smallest depth over which forcing can be applied. This only takes effect
+                                ! when near-surface layers become thin relative to this scale, in which case the
+                                ! forcing tendencies scaled down by distributing the forcing over this depth
+                                ! scale.
 EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
-                                ! The largest fraction of a layer than can be lost to forcing
-                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
-                                ! mass loss is passed down through the column.
+                                ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
+                                ! sea-ice formation) in one time-step. The unused mass loss is passed down
+                                ! through the column.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
-                                ! The density difference used to determine a diagnostic mixed
-                                ! layer depth, MLD_user, following the definition of Levitus 1982.
-                                ! The MLD is the depth at which the density is larger than the
-                                ! surface density by the specified amount.
+                                ! The density difference used to determine a diagnostic mixed layer depth,
+                                ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
+                                ! which the density is larger than the surface density by the specified amount.
 DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
-                                ! The distance over which to calculate a diagnostic of the
-                                ! stratification at the base of the mixed layer.
+                                ! The distance over which to calculate a diagnostic of the stratification at the
+                                ! base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
 ! See http://cvmix.github.io/
 USE_KPP = False                 !   [Boolean] default = False
-                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994,
-                                ! to calculate diffusivities and non-local transport in the OBL.
+                                ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
+                                ! diffusivities and non-local transport in the OBL.
 SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
-                                ! If true, place salt from brine rejection below the mixed layer,
-                                ! into the first non-vanished layer for which the column remains stable
+                                ! If true, place salt from brine rejection below the mixed layer, into the first
+                                ! non-vanished layer for which the column remains stable
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
 INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to
-                                ! drive diapycnal mixing, along the lines of St. Laurent
-                                ! et al. (2002) and Simmons et al. (2004).
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
 USE_CVMix_CONVECTION = False    !   [Boolean] default = False
-                                ! If true, turns on the enhanced mixing due to convection
-                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
-                                !  at statically unstable interfaces. Relevant parameters are
-                                ! contained in the CVMix_CONVECTION% parameter block.
+                                ! If true, turns on the enhanced mixing due to convection via CVMix. This scheme
+                                ! increases diapycnal diffs./viscs. at statically unstable interfaces. Relevant
+                                ! parameters are contained in the CVMix_CONVECTION% parameter block.
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 MAX_ENT_IT = 5                  ! default = 5
-                                ! The maximum number of iterations that may be used to
-                                ! calculate the interior diapycnal entrainment.
+                                ! The maximum number of iterations that may be used to calculate the interior
+                                ! diapycnal entrainment.
 TOLERANCE_ENT = 1.0E-13         !   [m] default = 1.0E-13
                                 ! The tolerance with which to solve for entrainment values.
 
 ! === module MOM_set_diffusivity ===
 FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
-                                ! The flux Richardson number where the stratification is
-                                ! large enough that N2 > omega2.  The full expression for
-                                ! the Flux Richardson number is usually
+                                ! The flux Richardson number where the stratification is large enough that N2 >
+                                ! omega2.  The full expression for the Flux Richardson number is usually
                                 ! FLUX_RI_MAX*N2/(N2+OMEGA2).
 ML_RADIATION = False            !   [Boolean] default = False
-                                ! If true, allow a fraction of TKE available from wind
-                                ! work to penetrate below the base of the mixed layer
-                                ! with a vertical decay scale determined by the minimum
-                                ! of: (1) The depth of the mixed layer, (2) an Ekman
-                                ! length scale.
+                                ! If true, allow a fraction of TKE available from wind work to penetrate below
+                                ! the base of the mixed layer with a vertical decay scale determined by the
+                                ! minimum of: (1) The depth of the mixed layer, (2) an Ekman length scale.
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
-                                ! The maximum decay scale for the BBL diffusion, or 0
-                                ! to allow the mixing to penetrate as far as
-                                ! stratification and rotation permit.  The default is 0.
+                                ! The maximum decay scale for the BBL diffusion, or 0 to allow the mixing to
+                                ! penetrate as far as stratification and rotation permit.  The default is 0.
                                 ! This is only used if BOTTOMDRAGLAW is true.
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the
-                                ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusivity from the BBL_mixing is simply added.
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
-                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
-                                ! the original BBL scheme.
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will
-                                ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics
-                                ! for an isopycnal layer-formulation.
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The minimum diapycnal diffusivity.
 KDML = 0.0                      !   [m2 s-1] default = 0.0
-                                ! If BULKMIXEDLAYER is false, KDML is the elevated
-                                ! diapycnal diffusivity in the topmost HMIX of fluid.
-                                ! KDML is only used if BULKMIXEDLAYER is false.
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated diapycnal diffusivity in the
+                                ! topmost HMIX of fluid. KDML is only used if BULKMIXEDLAYER is false.
 BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
-                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
-                                ! profile of background diapycnal diffusivity with depth.
-                                ! This is done via CVMix.
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh profile of background
+                                ! diapycnal diffusivity with depth. This is done via CVMix.
 HORIZ_VARYING_BACKGROUND = False !   [Boolean] default = False
-                                ! If true, apply vertically uniform, latitude-dependent background
-                                ! diffusivity, as described in Danabasoglu et al., 2012
+                                ! If true, apply vertically uniform, latitude-dependent background diffusivity,
+                                ! as described in Danabasoglu et al., 2012
 PRANDTL_BKGND = 1.0             !   [nondim] default = 1.0
-                                ! Turbulent Prandtl number used to convert vertical
-                                ! background diffusivities into viscosities.
+                                ! Turbulent Prandtl number used to convert vertical background diffusivities
+                                ! into viscosities.
 HENYEY_IGW_BACKGROUND = False   !   [Boolean] default = False
-                                ! If true, use a latitude-dependent scaling for the near
-                                ! surface background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a latitude-dependent scaling for the near surface background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
-                                ! If true, use a better latitude-dependent scaling for the
-                                ! background diffusivity, as described in
-                                ! Harrison & Hallberg, JPO 2008.
+                                ! If true, use a better latitude-dependent scaling for the background
+                                ! diffusivity, as described in Harrison & Hallberg, JPO 2008.
 KD_TANH_LAT_FN = False          !   [Boolean] default = False
-                                ! If true, use a tanh dependence of Kd_sfc on latitude,
-                                ! like CM2.1/CM2M.  There is no physical justification
-                                ! for this form, and it can not be used with
+                                ! If true, use a tanh dependence of Kd_sfc on latitude, like CM2.1/CM2M.  There
+                                ! is no physical justification for this form, and it can not be used with
                                 ! HENYEY_IGW_BACKGROUND.
 KD_MAX = -1.0                   !   [m2 s-1] default = -1.0
-                                ! The maximum permitted increment for the diapycnal
-                                ! diffusivity from TKE-based parameterizations, or a
-                                ! negative value for no limit.
+                                ! The maximum permitted increment for the diapycnal diffusivity from TKE-based
+                                ! parameterizations, or a negative value for no limit.
 KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
-                                ! A uniform diapycnal diffusivity that is added
-                                ! everywhere without any filtering or scaling.
+                                ! A uniform diapycnal diffusivity that is added everywhere without any filtering
+                                ! or scaling.
 USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, call user-defined code to change the diffusivity.
 DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
-                                ! The minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor).
+                                ! The minimum dissipation by which to determine a lower bound of Kd (a floor).
 DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
-                                ! The intercept when N=0 of the N-dependent expression
-                                ! used to set a minimum dissipation by which to determine
-                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+                                ! The intercept when N=0 of the N-dependent expression used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): A in eps_min
+                                ! = A + B*N.
 DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
-                                ! The coefficient multiplying N, following Gargett, used to
-                                ! set a minimum dissipation by which to determine a lower
-                                ! bound of Kd (a floor): B in eps_min = A + B*N
+                                ! The coefficient multiplying N, following Gargett, used to set a minimum
+                                ! dissipation by which to determine a lower bound of Kd (a floor): B in eps_min
+                                ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
-                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
-                                ! shear mixing parameterization.
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
+                                ! parameterization.
 VERTEX_SHEAR = False            !   [Boolean] default = False
-                                ! If true, do the calculations of the shear-driven mixing
-                                ! at the cell vertices (i.e., the vorticity points).
+                                ! If true, do the calculations of the shear-driven mixing at the cell vertices
+                                ! (i.e., the vorticity points).
 RINO_CRIT = 0.25                !   [nondim] default = 0.25
                                 ! The critical Richardson number for shear mixing.
 SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
-                                ! A nondimensional rate scale for shear-driven entrainment.
-                                ! Jackson et al find values in the range of 0.085-0.089.
+                                ! A nondimensional rate scale for shear-driven entrainment. Jackson et al find
+                                ! values in the range of 0.085-0.089.
 MAX_RINO_IT = 50                !   [nondim] default = 50
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the Richardson number driven mixing.
+                                ! The maximum number of iterations that may be used to estimate the Richardson
+                                ! number driven mixing.
 KD_KAPPA_SHEAR_0 = 0.0          !   [m2 s-1] default = 0.0
-                                ! The background diffusivity that is used to smooth the
-                                ! density and shear profiles before solving for the
-                                ! diffusivities. Defaults to value of KD.
+                                ! The background diffusivity that is used to smooth the density and shear
+                                ! profiles before solving for the diffusivities. Defaults to value of KD.
 FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
-                                ! The nondimensional curvature of the function of the
-                                ! Richardson number in the kappa source term in the
-                                ! Jackson et al. scheme.
+                                ! The nondimensional curvature of the function of the Richardson number in the
+                                ! kappa source term in the Jackson et al. scheme.
 TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
-                                ! The coefficient for the decay of TKE due to
-                                ! stratification (i.e. proportional to N*tke).
-                                ! The values found by Jackson et al. are 0.24-0.28.
+                                ! The coefficient for the decay of TKE due to stratification (i.e. proportional
+                                ! to N*tke). The values found by Jackson et al. are 0.24-0.28.
 TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
-                                ! The coefficient for the decay of TKE due to shear (i.e.
-                                ! proportional to |S|*tke). The values found by Jackson
-                                ! et al. are 0.14-0.12.
+                                ! The coefficient for the decay of TKE due to shear (i.e. proportional to
+                                ! |S|*tke). The values found by Jackson et al. are 0.14-0.12.
 KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
-                                ! The coefficient for the buoyancy length scale in the
-                                ! kappa equation.  The values found by Jackson et al. are
-                                ! in the range of 0.81-0.86.
+                                ! The coefficient for the buoyancy length scale in the kappa equation.  The
+                                ! values found by Jackson et al. are in the range of 0.81-0.86.
 KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
-                                ! The square of the ratio of the coefficients of the
-                                ! buoyancy and shear scales in the diffusivity equation,
-                                ! Set this to 0 (the default) to eliminate the shear scale.
-                                ! This is only used if USE_JACKSON_PARAM is true.
+                                ! The square of the ratio of the coefficients of the buoyancy and shear scales
+                                ! in the diffusivity equation, Set this to 0 (the default) to eliminate the
+                                ! shear scale. This is only used if USE_JACKSON_PARAM is true.
 KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
-                                ! The fractional error in kappa that is tolerated.
-                                ! Iteration stops when changes between subsequent
-                                ! iterations are smaller than this everywhere in a
-                                ! column.  The peak diffusivities usually converge most
-                                ! rapidly, and have much smaller errors than this.
+                                ! The fractional error in kappa that is tolerated. Iteration stops when changes
+                                ! between subsequent iterations are smaller than this everywhere in a column.
+                                ! The peak diffusivities usually converge most rapidly, and have much smaller
+                                ! errors than this.
 TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
-                                ! A background level of TKE used in the first iteration
-                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+                                ! A background level of TKE used in the first iteration of the kappa equation.
+                                ! TKE_BACKGROUND could be 0.
 KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
-                                ! If true, massless layers are merged with neighboring
-                                ! massive layers in this calculation.  The default is
-                                ! true and I can think of no good reason why it should
-                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+                                ! If true, massless layers are merged with neighboring massive layers in this
+                                ! calculation.  The default is true and I can think of no good reason why it
+                                ! should be false. This is only used if USE_JACKSON_PARAM is true.
 MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
-                                ! The maximum number of iterations that may be used to
-                                ! estimate the time-averaged diffusivity.
+                                ! The maximum number of iterations that may be used to estimate the
+                                ! time-averaged diffusivity.
 
 ! === module MOM_CVMix_shear ===
 ! Parameterization of shear-driven turbulence via CVMix (various options)
 USE_LMD94 = False               !   [Boolean] default = False
-                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
-                                ! shear mixing parameterization.
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994) shear mixing
+                                ! parameterization.
 USE_PP81 = False                !   [Boolean] default = False
-                                ! If true, use the Pacanowski and Philander (JPO 1981)
-                                ! shear mixing parameterization.
+                                ! If true, use the Pacanowski and Philander (JPO 1981) shear mixing
+                                ! parameterization.
 
 ! === module MOM_CVMix_ddiff ===
 ! Parameterization of mixing due to double diffusion processes via CVMix
 USE_CVMIX_DDIFF = False         !   [Boolean] default = False
-                                ! If true, turns on double diffusive processes via CVMix.
-                                ! Note that double diffusive processes on viscosity are ignored
-                                ! in CVMix, see http://cvmix.github.io/ for justification.
+                                ! If true, turns on double diffusive processes via CVMix. Note that double
+                                ! diffusive processes on viscosity are ignored in CVMix, see
+                                ! http://cvmix.github.io/ for justification.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
 RECLAIM_FRAZIL = True           !   [Boolean] default = True
-                                ! If true, try to use any frazil heat deficit to cool any
-                                ! overlying layers down to the freezing point, thereby
-                                ! avoiding the creation of thin ice when the SST is above
-                                ! the freezing point.
+                                ! If true, try to use any frazil heat deficit to cool any overlying layers down
+                                ! to the freezing point, thereby avoiding the creation of thin ice when the SST
+                                ! is above the freezing point.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
-                                ! If true, use a pressure dependent freezing temperature
-                                ! when making frazil. The default is false, which will be
-                                ! faster but is inappropriate with ice-shelf cavities.
+                                ! If true, use a pressure dependent freezing temperature when making frazil. The
+                                ! default is false, which will be faster but is inappropriate with ice-shelf
+                                ! cavities.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
-                                ! If true, use the fluxes%runoff_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+                                ! If true, use the fluxes%runoff_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*liq_runoff.
 USE_CALVING_HEAT_CONTENT = False !   [Boolean] default = False
-                                ! If true, use the fluxes%calving_Hflx field to set the
-                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+                                ! If true, use the fluxes%calving_Hflx field to set the heat carried by runoff,
+                                ! instead of using SST*CP*froz_runoff.
 
 ! === module MOM_regularize_layers ===
 REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
-                                ! If defined, vertically restructure the near-surface
-                                ! layers when they have too much lateral variations to
-                                ! allow for sensible lateral barotropic transports.
+                                ! If defined, vertically restructure the near-surface layers when they have too
+                                ! much lateral variations to allow for sensible lateral barotropic transports.
 HMIX_MIN = 0.0                  !   [m] default = 0.0
-                                ! The minimum mixed layer depth if the mixed layer depth
-                                ! is determined dynamically.
+                                ! The minimum mixed layer depth if the mixed layer depth is determined
+                                ! dynamically.
 REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
-                                ! The value of the relative thickness deficit at which
-                                ! to start modifying the layer structure when
-                                ! REGULARIZE_SURFACE_LAYERS is true.
+                                ! The value of the relative thickness deficit at which to start modifying the
+                                ! layer structure when REGULARIZE_SURFACE_LAYERS is true.
 ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
-                                ! If true, clocks can be called from inside loops that can
-                                ! be threaded. To run with multiple threads, set to False.
+                                ! If true, clocks can be called from inside loops that can be threaded. To run
+                                ! with multiple threads, set to False.
 
 ! === module MOM_opacity ===
 VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
+                                ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
+                                ! the e-folding depth of incoming short wave radiation.
 EXP_OPACITY_SCHEME = "SINGLE_EXP" ! default = "SINGLE_EXP"
-                                ! This character string specifies which exponential
-                                ! opacity scheme to utilize. Currently
-                                ! valid options include:
+                                ! This character string specifies which exponential opacity scheme to utilize.
+                                ! Currently valid options include:
                                 !        SINGLE_EXP - Single Exponent decay.
                                 !        DOUBLE_EXP - Double Exponent decay.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 PEN_SW_NBANDS = 1               ! default = 1
                                 ! The number of bands of penetrating shortwave radiation.
 OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
-                                ! The value to use for opacity over land. The default is
-                                ! 10 m-1 - a value for muddy water.
+                                ! The value to use for opacity over land. The default is 10 m-1 - a value for
+                                ! muddy water.
 
 ! === module MOM_tracer_advect ===
 TRACER_ADVECTION_SCHEME = "PLM" ! default = "PLM"
@@ -1492,101 +1324,90 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 NDIFF_CONTINUOUS = True         !   [Boolean] default = True
-                                ! If true, uses a continuous reconstruction of T and S when
-                                ! finding neutral surfaces along which diffusion will happen.
-                                ! If false, a PPM discontinuous reconstruction of T and S
-                                ! is done which results in a higher order routine but exacts
-                                ! a higher computational cost.
+                                ! If true, uses a continuous reconstruction of T and S when finding neutral
+                                ! surfaces along which diffusion will happen. If false, a PPM discontinuous
+                                ! reconstruction of T and S is done which results in a higher order routine but
+                                ! exacts a higher computational cost.
 NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
-                                ! The reference pressure (Pa) used for the derivatives of
-                                ! the equation of state. If negative (default), local
-                                ! pressure is used.
+                                ! The reference pressure (Pa) used for the derivatives of the equation of state.
+                                ! If negative (default), local pressure is used.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 5.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -1594,8 +1415,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -1603,48 +1423,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 0.0                   !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -1652,12 +1465,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.debugging
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.debugging
@@ -7,54 +7,47 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
-                                ! The maximum number of colums of truncations that any PE
-                                ! will write out during a run.
+                                ! The maximum number of colums of truncations that any PE will write out during
+                                ! a run.
 DEBUG_BT = False                !   [Boolean] default = False
-                                ! If true, write out verbose debugging data within the
-                                ! barotropic time-stepping loop. The data volume can be
-                                ! quite large if this is true.
+                                ! If true, write out verbose debugging data within the barotropic time-stepping
+                                ! loop. The data volume can be quite large if this is true.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
 DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
                                 ! If true, write debugging data for the kappa-shear code.
-                                ! Caution: this option is _very_ verbose and should only
-                                ! be used in single-column mode!
+                                ! Caution: this option is _very_ verbose and should only be used in
+                                ! single-column mode!
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.layout
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.layout
@@ -1,70 +1,63 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 2                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 2, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
-                                ! If true, use wide halos and march in during the
-                                ! barotropic time stepping for efficiency.
+                                ! If true, use wide halos and march in during the barotropic time stepping for
+                                ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
 !BT x-halo = 0                  !

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
@@ -5,21 +5,18 @@
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 DT = 3600.0                     !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
-                                ! The heat capacity of sea water, approximated as a
-                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
-                                ! true. The default value is from the TEOS-10 definition
-                                ! of conservative temperature.
+                                ! The heat capacity of sea water, approximated as a constant. This is only used
+                                ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
+                                ! definition of conservative temperature.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "Initial_state" ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 
@@ -29,13 +26,11 @@ REENTRANT_X = False             !   [Boolean] default = True
 REENTRANT_Y = True              !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 NIGLOBAL = 20                   !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -45,10 +40,9 @@ NJGLOBAL = 4                    !
 G_EARTH = 10.0                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 NK = 10                         !   [nondim]
@@ -60,8 +54,8 @@ INPUTDIR = "INPUT"              ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -73,8 +67,8 @@ AXIS_UNITS = "k"                ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [k]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 40.0                   !   [k]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 200.0                  !   [k]
@@ -111,8 +105,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -124,17 +118,14 @@ ROTATION = "beta"               ! default = "2omegasinlat"
 
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
-                                ! EQN_OF_STATE determines which ocean equation of state
-                                ! should be used.  Currently, the valid choices are
-                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
-                                ! This is only used if USE_EOS is true.
+                                ! EQN_OF_STATE determines which ocean equation of state should be used.
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
+                                ! "TEOS10". This is only used if USE_EOS is true.
 DRHO_DT = 0.0                   !   [kg m-3 K-1] default = -0.2
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! temperature.
 DRHO_DS = 1.0                   !   [kg m-3 PSU-1] default = 0.8
-                                ! When EQN_OF_STATE=LINEAR,
-                                ! this is the partial derivative of density with
+                                ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
 ! === module MOM_restart ===
@@ -161,15 +152,12 @@ COORD_CONFIG = "linear"         !
                                 !       (read from COORD_FILE) to set layer densities.
                                 !     USER - call a user modified routine.
 LIGHTEST_DENSITY = 1034.5       !   [kg m-3] default = 1000.0
-                                ! The reference potential density used for the surface
-                                ! interface.
+                                ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 1.0             !   [kg m-3] default = 2.0
-                                ! The range of reference potential densities across
-                                ! all interfaces.
+                                ! The range of reference potential densities across all interfaces.
 REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
-                                ! Coordinate mode for vertical regridding.
-                                ! Choose among the following possibilities:
-                                !  LAYER - Isopycnal or stacked shallow water layers
+                                ! Coordinate mode for vertical regridding. Choose among the following
+                                ! possibilities:  LAYER - Isopycnal or stacked shallow water layers
                                 !  ZSTAR, Z* - stretched geopotential z*
                                 !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
@@ -184,13 +172,11 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
-                                ! When regridding, this is the minimum layer
-                                ! thickness allowed.
+                                ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
-                                ! This sets the reconstruction scheme used
-                                ! for vertical remapping for all variables.
-                                ! It can be one of the following schemes:
-                                ! PCM         (1st-order accurate)
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
                                 ! PPM_IH4     (3rd-order accurate)
@@ -202,8 +188,8 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -229,8 +215,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 TS_CONFIG = "baroclinic_zone"   !
-                                ! A string that determines how the initial tempertures
-                                ! and salinities are specified for a new run:
+                                ! A string that determines how the initial tempertures and salinities are
+                                ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
                                 !     fit - find the temperatures that are consistent with
@@ -272,45 +258,40 @@ L_ZONE = 100.0                  !   [kilometers] default = 20.0
 
 ! === module MOM_set_visc ===
 HBBL = 0.001                    !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of
-                                ! the velocity field to the bottom stress. CDRAG is only
-                                ! used if BOTTOMDRAGLAW is defined.
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
 BBL_THICK_MIN = 0.01            !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 KV = 1.0E-06                    !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 ETA_TOLERANCE = 1.0E-12         !   [m] default = 5.000000000000001E-15
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 
 ! === module MOM_CoriolisAdv ===
 BOUND_CORIOLIS = True           !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_GUDONOV"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 
 ! === module MOM_PressureForce ===
@@ -323,48 +304,40 @@ LAPLACIAN = True                !   [Boolean] default = False
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
 SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 BIHARMONIC = False              !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HMIX_FIXED = 1.0E-10            !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 
 ! === module MOM_PointAccel ===
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False
-                                ! If true, the corrective pseudo mass-fluxes into the
-                                ! barotropic solver are limited to values that require
-                                ! less than maxCFL_BT_cont to be accommodated.
+                                ! If true, the corrective pseudo mass-fluxes into the barotropic solver are
+                                ! limited to values that require less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
-                                ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendency by 1+BEBT when calculating the
-                                ! transport.  The default (false) is to use a predictor
-                                ! continuity step to find the pressure field, and then
-                                ! to do a corrector continuity step using a weighted
-                                ! average of the old and new velocities, with weights
-                                ! of (1-BEBT) and BEBT.
+                                ! If true, step the barotropic velocity first and project out the velocity
+                                ! tendency by 1+BEBT when calculating the transport.  The default (false) is to
+                                ! use a predictor continuity step to find the pressure field, and then to do a
+                                ! corrector continuity step using a weighted average of the old and new
+                                ! velocities, with weights of (1-BEBT) and BEBT.
 BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
-                                ! A string describing the scheme that is used to set the
-                                ! open face areas used for barotropic transport and the
-                                ! relative weights of the accelerations. Valid values are:
+                                ! A string describing the scheme that is used to set the open face areas used
+                                ! for barotropic transport and the relative weights of the accelerations. Valid
+                                ! values are:
                                 !    ARITHMETIC - arithmetic mean layer thicknesses
                                 !    HARMONIC - harmonic mean layer thicknesses
                                 !    HYBRID (the default) - use arithmetic means for
@@ -374,20 +347,17 @@ BT_THICK_SCHEME = "HYBRID"      ! default = "FROM_BT_CONT"
                                 !    FROM_BT_CONT - use the average thicknesses kept
                                 !       in the h_u and h_v fields of the BT_cont_type
 BEBT = 0.2                      !   [nondim] default = 0.1
-                                ! BEBT determines whether the barotropic time stepping
-                                ! uses the forward-backward time-stepping scheme or a
-                                ! backward Euler scheme. BEBT is valid in the range from
-                                ! 0 (for a forward-backward treatment of nonrotating
-                                ! gravity waves) to 1 (for a backward Euler treatment).
-                                ! In practice, BEBT must be greater than about 0.05.
+                                ! BEBT determines whether the barotropic time stepping uses the forward-backward
+                                ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range
+                                ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
+                                ! (for a backward Euler treatment). In practice, BEBT must be greater than about
+                                ! 0.05.
 DTBT = 5.0                      !   [s or nondim] default = -0.98
-                                ! The barotropic time step, in s. DTBT is only used with
-                                ! the split explicit time stepping. To set the time step
-                                ! automatically based the maximum stable value use 0, or
-                                ! a negative value gives the fraction of the stable value.
-                                ! Setting DTBT to 0 is the same as setting it to -0.98.
-                                ! The value of DTBT that will actually be used is an
-                                ! integer fraction of DT, rounding down.
+                                ! The barotropic time step, in s. DTBT is only used with the split explicit time
+                                ! stepping. To set the time step automatically based the maximum stable value
+                                ! use 0, or a negative value gives the fraction of the stable value. Setting
+                                ! DTBT to 0 is the same as setting it to -0.98. The value of DTBT that will
+                                ! actually be used is an integer fraction of DT, rounding down.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -410,22 +380,19 @@ DTBT = 5.0                      !   [s or nondim] default = -0.98
 
 ! === module MOM_entrain_diffusive ===
 CORRECT_DENSITY = False         !   [Boolean] default = True
-                                ! If true, and USE_EOS is true, the layer densities are
-                                ! restored toward their target values by the diapycnal
-                                ! mixing, as described in Hallberg (MWR, 2000).
+                                ! If true, and USE_EOS is true, the layer densities are restored toward their
+                                ! target values by the diapycnal mixing, as described in Hallberg (MWR, 2000).
 
 ! === module MOM_set_diffusivity ===
 BBL_EFFIC = 0.0                 !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by
-                                ! bottom drag drives BBL diffusion.  This is only
-                                ! used if BOTTOMDRAGLAW is true.
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 KD = 0.0                        !   [m2 s-1]
-                                ! The background diapycnal diffusivity of density in the
-                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
-                                ! may be used.
+                                ! The background diapycnal diffusivity of density in the interior. Zero or the
+                                ! molecular value, ~1e-7 m2 s-1, may be used.
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -443,11 +410,10 @@ KD = 0.0                        !   [m2 s-1]
 
 ! === module MOM_opacity ===
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
-                                ! The vertical absorption e-folding depth of the
-                                ! penetrating shortwave radiation.
+                                ! The vertical absorption e-folding depth of the penetrating shortwave
+                                ! radiation.
 PEN_SW_FRAC = 0.42              !   [nondim] default = 0.0
-                                ! The fraction of the shortwave radiation that penetrates
-                                ! below the surface.
+                                ! The fraction of the shortwave radiation that penetrates below the surface.
 
 ! === module MOM_tracer_advect ===
 
@@ -462,53 +428,46 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
 
 ! === module MOM_sum_output ===
 MAXTRUNC = 10                   !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 ENERGYSAVEDAYS = 5.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "NONE"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 20.0                   !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 RESTART_CONTROL = 3             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 
 ! === module MOM_write_cputime ===
 MAXCPU = 2.88E+04               !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 
 ! === module MOM_file_parser ===

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -9,121 +9,103 @@ SPLIT = False                   !   [Boolean] default = True
 USE_RK2 = False                 !   [Boolean] default = False
                                 ! If true, use RK2 instead of RK3 in the unsplit time stepping.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
-                                ! If true, the in-situ density is used to calculate the
-                                ! effective sea level that is returned to the coupler. If false,
-                                ! the Boussinesq parameter RHO_0 is used.
+                                ! If true, the in-situ density is used to calculate the effective sea level that
+                                ! is returned to the coupler. If false, the Boussinesq parameter RHO_0 is used.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 USE_EOS = False                 !   [Boolean] default = False
-                                ! If true,  density is calculated from temperature and
-                                ! salinity with an equation of state.  If USE_EOS is
-                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+                                ! If true,  density is calculated from temperature and salinity with an equation
+                                ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
 DIABATIC_FIRST = False          !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes,
-                                ! including buoyancy forcing and mass gain or loss,
-                                ! before stepping the dynamics forward.
+                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
+                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
-                                ! If true, the prognostics T&S are the conservative temperature
-                                ! and absolute salinity. Care should be taken to convert them
-                                ! to potential temperature and practical salinity before
-                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+                                ! If true, the prognostics T&S are the conservative temperature and absolute
+                                ! salinity. Care should be taken to convert them to potential temperature and
+                                ! practical salinity before exchanging them with the coupler and/or reporting
+                                ! T&S diagnostics.
 ADIABATIC = True                !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 USE_LEGACY_DIABATIC_DRIVER = True !   [Boolean] default = True
-                                ! If true, use a legacy version of the diabatic subroutine.
-                                ! This is temporary and is needed to avoid change in answers.
+                                ! If true, use a legacy version of the diabatic subroutine. This is temporary
+                                ! and is needed to avoid change in answers.
 OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
-                                ! If true, barotropic and baroclinic dynamics, thermodynamics
-                                ! are all bypassed with all the fields necessary to integrate
-                                ! the tracer advection and diffusion equation are read in from
-                                ! files stored from a previous integration of the prognostic model.
-                                ! NOTE: This option only used in the ocean_solo_driver.
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics are all bypassed
+                                ! with all the fields necessary to integrate the tracer advection and diffusion
+                                ! equation are read in from files stored from a previous integration of the
+                                ! prognostic model. NOTE: This option only used in the ocean_solo_driver.
 USE_REGRIDDING = False          !   [Boolean] default = False
-                                ! If True, use the ALE algorithm (regridding/remapping).
-                                ! If False, use the layered isopycnal algorithm.
+                                ! If True, use the ALE algorithm (regridding/remapping). If False, use the
+                                ! layered isopycnal algorithm.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
-                                ! If true, use a Kraus-Turner-like bulk mixed layer
-                                ! with transitional buffer layers.  Layers 1 through
-                                ! NKML+NKBL have variable densities. There must be at
-                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
-                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
-                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+                                ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
+                                ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
+                                ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
 THICKNESSDIFFUSE = False        !   [Boolean] default = False
-                                ! If true, interface heights are diffused with a
-                                ! coefficient of KHTH.
+                                ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
-                                ! If true, do thickness diffusion before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE is true.
+                                ! If true, do thickness diffusion before dynamics. This is only used if
+                                ! THICKNESSDIFFUSE is true.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths
-                                ! at velocity points.  Otherwise the effects of topography
-                                ! are entirely determined from thickness points.
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
 DT = 8.64E+04                   !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 DT_THERM = 8.64E+04             !   [s] default = 8.64E+04
-                                ! The thermodynamic and tracer advection time step.
-                                ! Ideally DT_THERM should be an integer multiple of DT
-                                ! and less than the forcing or coupling time-step, unless
-                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
-                                ! can be an integer multiple of the coupling timestep.  By
-                                ! default DT_THERM is set to DT.
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer
-                                ! timesteps that can be longer than the coupling timestep.
-                                ! The actual thermodynamic timestep that is used in this
-                                ! case is the largest integer multiple of the coupling
-                                ! timestep that is less than or equal to DT_THERM.
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
-                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
-                                ! over which to average to find surface properties like
-                                ! SST and SSS or density (but not surface velocities).
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
+                                ! to find surface properties like SST and SSS or density (but not surface
+                                ! velocities).
 HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
-                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
-                                ! over which to average to find surface flow properties,
-                                ! SSU, SSV. A non-positive value indicates no averaging.
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
+                                ! average to find surface flow properties, SSU, SSV. A non-positive value
+                                ! indicates no averaging.
 HFREEZE = -1.0                  !   [m] default = -1.0
-                                ! If HFREEZE > 0, melt potential will be computed. The actual depth
-                                ! over which melt potential is computed will be min(HFREEZE, OBLD),
-                                ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
-                                ! melt potential will not be computed.
+                                ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
+                                ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
+                                ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
+                                ! computed.
 MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
+                                ! The minimum amount of time in seconds between calculations of depth-space
+                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
-                                ! If true, linearly interpolate the surface pressure
-                                ! over the coupling time step, using the specified value
-                                ! at the end of the step.
+                                ! If true, linearly interpolate the surface pressure over the coupling time
+                                ! step, using the specified value at the end of the step.
 FIRST_DIRECTION = 0             ! default = 0
-                                ! An integer that indicates which direction goes first
-                                ! in parts of the code that use directionally split
-                                ! updates, with even numbers (or 0) used for x- first
+                                ! An integer that indicates which direction goes first in parts of the code that
+                                ! use directionally split updates, with even numbers (or 0) used for x- first
                                 ! and odd numbers used for y-first.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
 SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
-                                ! If true, write the initial conditions to a file given
-                                ! by IC_OUTPUT_FILE.
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
 WRITE_GEOM = 1                  ! default = 1
-                                ! If =0, never write the geometry and vertical grid files.
-                                ! If =1, write the geometry and vertical grid files only for
-                                ! a new simulation. If =2, always write the geometry and
-                                ! vertical grid files. Other values are invalid.
+                                ! If =0, never write the geometry and vertical grid files. If =1, write the
+                                ! geometry and vertical grid files only for a new simulation. If =2, always
+                                ! write the geometry and vertical grid files. Other values are invalid.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
-                                ! If False, The model is being run in serial mode as a single realization.
-                                ! If True, The current model realization is part of a larger ensemble
-                                ! and at the end of step MOM, we will perform a gather of the ensemble
-                                ! members for statistical evaluation and/or data assimilation.
+                                ! If False, The model is being run in serial mode as a single realization. If
+                                ! True, The current model realization is part of a larger ensemble and at the
+                                ! end of step MOM, we will perform a gather of the ensemble members for
+                                ! statistical evaluation and/or data assimilation.
 
 ! === module MOM_domains ===
 REENTRANT_X = True              !   [Boolean] default = True
@@ -131,16 +113,14 @@ REENTRANT_X = True              !   [Boolean] default = True
 REENTRANT_Y = False             !   [Boolean] default = False
                                 ! If true, the domain is meridionally reentrant.
 TRIPOLAR_N = False              !   [Boolean] default = False
-                                ! Use tripolar connectivity at the northern edge of the
-                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+                                ! Use tripolar connectivity at the northern edge of the domain.  With
+                                ! TRIPOLAR_N, NIGLOBAL must be even.
 NIGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -150,17 +130,15 @@ NJGLOBAL = 4                    !
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
 RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
-                                ! The mean ocean density used with BOUSSINESQ true to
-                                ! calculate accelerations and the mass for conservation
-                                ! properties, or with BOUSSINSEQ false to convert some
-                                ! parameters from vertical units of m to kg m-2.
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
                                 ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
-                                ! A constant that translates the model's internal
-                                ! units of thickness into m.
+                                ! A constant that translates the model's internal units of thickness into m.
 NK = 1                          !   [nondim]
                                 ! The number of model layers.
 
@@ -170,8 +148,8 @@ INPUTDIR = "."                  ! default = "."
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
@@ -183,13 +161,13 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     m - meters
                                 !     k - kilometers
 SOUTHLAT = 0.0                  !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 WESTLON = 0.0                   !   [degrees] default = 0.0
-                                ! The western longitude of the domain or the equivalent
-                                ! starting value for the x-axis.
+                                ! The western longitude of the domain or the equivalent starting value for the
+                                ! x-axis.
 LENLON = 1.0                    !   [degrees]
                                 ! The longitudinal or x-direction length of the domain.
 RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
@@ -226,13 +204,13 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
-                                ! The depth below which to mask points as land points, for which all
-                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+                                ! The depth below which to mask points as land points, for which all fluxes are
+                                ! zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -253,12 +231,12 @@ ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
 OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
                                 ! The rotation rate of the earth.
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold.
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file,
-                                ! otherwise a single restart file is generated
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_registry ===
 
@@ -266,15 +244,15 @@ PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
 RESTARTFILE = "MOM.res"         ! default = "MOM.res"
                                 ! The name-root of the restart file.
 LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
-                                ! If true, use the file-size limits with NetCDF large
-                                ! file support (4Gb), otherwise the limit is 2Gb.
+                                ! If true, use the file-size limits with NetCDF large file support (4Gb),
+                                ! otherwise the limit is 2Gb.
 MAX_FIELDS = 100                ! default = 100
                                 ! The maximum number of restart fields that can be used.
 RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
-                                ! If true, require the restart checksums to match and error out otherwise.
-                                ! Users may want to avoid this comparison if for example the restarts are
-                                ! made from a run with a different mask_table than the current run,
-                                ! in which case the checksums will not match and cause crash.
+                                ! If true, require the restart checksums to match and error out otherwise. Users
+                                ! may want to avoid this comparison if for example the restarts are made from a
+                                ! run with a different mask_table than the current run, in which case the
+                                ! checksums will not match and cause crash.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -294,8 +272,8 @@ USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
 USE_OCMIP2_CFC = False          !   [Boolean] default = False
                                 ! If true, use the MOM_OCMIP2_CFC tracer package.
 USE_generic_tracer = False      !   [Boolean] default = False
-                                ! If true and _USE_GENERIC_TRACER is defined as a
-                                ! preprocessor macro, use the MOM_generic_tracer packages.
+                                ! If true and _USE_GENERIC_TRACER is defined as a preprocessor macro, use the
+                                ! MOM_generic_tracer packages.
 USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
                                 ! If true, use the pseudo salt tracer, typically run as a diagnostic.
 USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
@@ -330,12 +308,11 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures,
-                                ! and salinities from a Z-space file on a latitude-
-                                ! longitude grid.
+                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
+                                ! Z-space file on a latitude-longitude grid.
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -361,8 +338,8 @@ THICKNESS_CONFIG = "uniform"    !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities
-                                ! are specified for a new run:
+                                ! A string that determines how the initial velocities are specified for a new
+                                ! run:
                                 !     file - read velocities from the file specified
                                 !       by (VELOCITY_FILE).
                                 !     zero - the fluid is initially at rest.
@@ -372,41 +349,38 @@ VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 !     soliton - Equatorial Rossby soliton.
                                 !     USER - call a user modified routine.
 CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
-                                ! If true,  convert the thickness initial conditions from
-                                ! units of m to kg m-2 or vice versa, depending on whether
-                                ! BOUSSINESQ is defined. This does not apply if a restart
-                                ! file is read.
+                                ! If true,  convert the thickness initial conditions from units of m to kg m-2
+                                ! or vice versa, depending on whether BOUSSINESQ is defined. This does not apply
+                                ! if a restart file is read.
 DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge
-                                ! tsunamis when a large surface pressure is applied.
+                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
+                                ! surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic pressure matches the imposed
-                                ! surface pressure which is read from file.
+                                ! If true, cuts way the top of the column for initial conditions at the depth
+                                ! where the hydrostatic pressure matches the imposed surface pressure which is
+                                ! read from file.
 SPONGE = False                  !   [Boolean] default = False
-                                ! If true, sponges may be applied anywhere in the domain.
-                                ! The exact location and properties of those sponges are
-                                ! specified via SPONGE_CONFIG.
+                                ! If true, sponges may be applied anywhere in the domain. The exact location and
+                                ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
-                                ! The number of diagnostic vertical coordinates to use.
-                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
-                                ! A list of string tuples associating diag_table modules to
-                                ! a coordinate definition used for diagnostics. Each string
-                                ! is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
+                                ! PARAMETER_SUFFIX COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
-                                ! Instead of writing diagnostics to the diag manager, write
-                                ! a text file containing the checksum (bitcount) of the array.
+                                ! Instead of writing diagnostics to the diag manager, write a text file
+                                ! containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
-                                ! A file into which to write a list of all available
-                                ! ocean diagnostics that can be included in a diag_table.
+                                ! A file into which to write a list of all available ocean diagnostics that can
+                                ! be included in a diag_table.
 DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
-                                ! Determines how to specify the coordinate
-                                ! resolution. Valid options are:
+                                ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
@@ -422,94 +396,82 @@ DIAG_COORD_DEF_Z = "UNIFORM"    ! default = "UNIFORM"
 
 ! === module MOM_MEKE ===
 USE_MEKE = False                !   [Boolean] default = False
-                                ! If true, turns on the MEKE scheme which calculates
-                                ! a sub-grid mesoscale eddy kinetic energy budget.
+                                ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
+                                ! kinetic energy budget.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = False     !   [Boolean] default = False
-                                ! If true, the variable mixing code will be called.  This
-                                ! allows diagnostics to be created even if the scheme is
-                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
-                                ! this is set to true regardless of what is in the
-                                ! parameter file.
+                                ! If true, the variable mixing code will be called.  This allows diagnostics to
+                                ! be created even if the scheme is not used.  If KHTR_SLOPE_CFF>0 or
+                                ! KhTh_Slope_Cff>0, this is set to true regardless of what is in the parameter
+                                ! file.
 RESOLN_SCALED_KH = False        !   [Boolean] default = False
-                                ! If true, the Laplacian lateral viscosity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the Laplacian lateral viscosity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTH = False      !   [Boolean] default = False
-                                ! If true, the interface depth diffusivity is scaled away
-                                ! when the first baroclinic deformation radius is well
-                                ! resolved.
+                                ! If true, the interface depth diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
-                                ! If true, the epipycnal tracer diffusivity is scaled
-                                ! away when the first baroclinic deformation radius is
-                                ! well resolved.
+                                ! If true, the epipycnal tracer diffusivity is scaled away when the first
+                                ! baroclinic deformation radius is well resolved.
 RESOLN_USE_EBT = False          !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic wave speed instead
-                                ! of first baroclinic wave for calculating the resolution fn.
+                                ! If true, uses the equivalent barotropic wave speed instead of first baroclinic
+                                ! wave for calculating the resolution fn.
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
-                                ! If true, uses the equivalent barotropic structure
-                                ! as the vertical structure of thickness diffusivity.
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! thickness diffusivity.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the interface depth diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the interface depth
+                                ! diffusivity
 KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
+                                ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
+                                ! diffusivity
 USE_STORED_SLOPES = False       !   [Boolean] default = False
-                                ! If true, the isopycnal slopes are calculated once and
-                                ! stored for re-use. This uses more memory but avoids calling
-                                ! the equation of state more times than should be necessary.
+                                ! If true, the isopycnal slopes are calculated once and stored for re-use. This
+                                ! uses more memory but avoids calling the equation of state more times than
+                                ! should be necessary.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = False           !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 CHANNEL_DRAG = False            !   [Boolean] default = False
-                                ! If true, the bottom drag is exerted directly on each
-                                ! layer proportional to the fraction of the bottom it
-                                ! overlies.
+                                ! If true, the bottom drag is exerted directly on each layer proportional to the
+                                ! fraction of the bottom it overlies.
 LINEAR_DRAG = False             !   [Boolean] default = False
-                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
-                                ! law is cdrag*DRAG_BG_VEL*u.
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
+                                ! cdrag*DRAG_BG_VEL*u.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear
-                                ! instability.
+                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
-                                ! If true, use a bulk Richardson number criterion to
-                                ! determine the mixed layer thickness for viscosity.
+                                ! If true, use a bulk Richardson number criterion to determine the mixed layer
+                                ! thickness for viscosity.
 HBBL = 1.0                      !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 BBL_THICK_MIN = 0.0             !   [m] default = 0.0
-                                ! The minimum bottom boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! The minimum bottom boundary layer thickness that can be used with
+                                ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
 HTBL_SHELF_MIN = 0.0            !   [m] default = 0.0
-                                ! The minimum top boundary layer thickness that can be
-                                ! used with BOTTOMDRAGLAW. This might be
-                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
-                                ! near-top viscosity.
+                                ! The minimum top boundary layer thickness that can be used with BOTTOMDRAGLAW.
+                                ! This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum near-top
+                                ! viscosity.
 HTBL_SHELF = 1.0                !   [m] default = 1.0
-                                ! The thickness over which near-surface velocities are
-                                ! averaged for the drag law under an ice shelf.  By
-                                ! default this is the same as HBBL
+                                ! The thickness over which near-surface velocities are averaged for the drag law
+                                ! under an ice shelf.  By default this is the same as HBBL
 KV = 1.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convection) is added
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
+                                ! If true, the background vertical viscosity in the interior (i.e., tidal +
+                                ! background + shear + convection) is added when computing the coupling
+                                ! coefficient. The purpose of this flag is to be able to recover previous
+                                ! answers and it will likely be removed in the future since this option should
+                                ! always be true.
 KV_BBL_MIN = 1.0                !   [m2 s-1] default = 1.0
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 1.0                !   [m2 s-1] default = 1.0
@@ -519,82 +481,70 @@ TIDES = False                   !   [Boolean] default = False
 
 ! === module MOM_continuity ===
 CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
-                                ! CONTINUITY_SCHEME selects the discretization for the
-                                ! continuity solver. The only valid value currently is:
+                                ! CONTINUITY_SCHEME selects the discretization for the continuity solver. The
+                                ! only valid value currently is:
                                 !    PPM - use a positive-definite (or monotonic)
                                 !          piecewise parabolic reconstruction solver.
 
 ! === module MOM_continuity_PPM ===
 MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
-                                ! monotonic limiter.  The default (false) is to use a
-                                ! simple positive definite limiter.
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward monotonic limiter.  The
+                                ! default (false) is to use a simple positive definite limiter.
 SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
-                                ! continuity solver.  This scheme is highly diffusive
-                                ! but may be useful for debugging or in single-column
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
+                                ! scheme is highly diffusive but may be useful for debugging or in single-column
                                 ! mode where its minimal stencil is useful.
 ETA_TOLERANCE = 5.0E-11         !   [m] default = 5.0E-11
-                                ! The tolerance for the differences between the
-                                ! barotropic and baroclinic estimates of the sea surface
-                                ! height due to the fluxes through each face.  The total
-                                ! tolerance for SSH is 4 times this value.  The default
-                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
-                                ! than about 10^-15*MAXIMUM_DEPTH.
+                                ! The tolerance for the differences between the barotropic and baroclinic
+                                ! estimates of the sea surface height due to the fluxes through each face.  The
+                                ! total tolerance for SSH is 4 times this value.  The default is
+                                ! 0.5*NK*ANGSTROM, and this should not be set less than about
+                                ! 10^-15*MAXIMUM_DEPTH.
 ETA_TOLERANCE_AUX = 5.0E-11     !   [m] default = 5.0E-11
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+                                ! The tolerance for free-surface height discrepancies between the barotropic
+                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
+                                ! be made larger for efficiency.
 VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
+                                ! The tolerance for barotropic velocity discrepancies between the barotropic
+                                ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
-                                ! If true, allow the adjusted velocities to have a
-                                ! relative CFL change up to 0.5.
+                                ! If true, allow the adjusted velocities to have a relative CFL change up to
+                                ! 0.5.
 CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
-                                ! If true, use the ratio of the open face lengths to the
-                                ! tracer cell areas when estimating CFL numbers.  The
-                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+                                ! If true, use the ratio of the open face lengths to the tracer cell areas when
+                                ! estimating CFL numbers.  The default is set by CONT_PPM_AGGRESS_ADJUST.
 CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
                                 ! The maximum CFL of the adjusted velocities.
 CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
-                                ! If true, stop corrective iterations using a velocity
-                                ! based criterion and only stop if the iteration is
-                                ! better than all predecessors.
+                                ! If true, stop corrective iterations using a velocity based criterion and only
+                                ! stop if the iteration is better than all predecessors.
 CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
-                                ! If true, use more appropriate limiting bounds for
-                                ! corrections in strongly viscous columns.
+                                ! If true, use more appropriate limiting bounds for corrections in strongly
+                                ! viscous columns.
 CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
-                                ! If true, use the marginal face areas from the continuity
-                                ! solver for use as the weights in the barotropic solver.
-                                ! Otherwise use the transport averaged areas.
+                                ! If true, use the marginal face areas from the continuity solver for use as the
+                                ! weights in the barotropic solver. Otherwise use the transport averaged areas.
 
 ! === module MOM_CoriolisAdv ===
 NOSLIP = False                  !   [Boolean] default = False
-                                ! If true, no slip boundary conditions are used; otherwise
-                                ! free slip boundary conditions are assumed. The
-                                ! implementation of the free slip BCs on a C-grid is much
-                                ! cleaner than the no slip BCs. The use of free slip BCs
-                                ! is strongly encouraged, and no slip BCs are not used with
-                                ! the biharmonic viscosity.
+                                ! If true, no slip boundary conditions are used; otherwise free slip boundary
+                                ! conditions are assumed. The implementation of the free slip BCs on a C-grid is
+                                ! much cleaner than the no slip BCs. The use of free slip BCs is strongly
+                                ! encouraged, and no slip BCs are not used with the biharmonic viscosity.
 CORIOLIS_EN_DIS = False         !   [Boolean] default = False
-                                ! If true, two estimates of the thickness fluxes are used
-                                ! to estimate the Coriolis term, and the one that
-                                ! dissipates energy relative to the other one is used.
+                                ! If true, two estimates of the thickness fluxes are used to estimate the
+                                ! Coriolis term, and the one that dissipates energy relative to the other one is
+                                ! used.
 CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
-                                ! CORIOLIS_SCHEME selects the discretization for the
-                                ! Coriolis terms. Valid values are:
+                                ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
+                                ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
                                 !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
                                 !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
@@ -602,148 +552,125 @@ CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
                                 !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
                                 !                         Arakawa & Hsu and Sadourny energy
 BOUND_CORIOLIS = False          !   [Boolean] default = False
-                                ! If true, the Coriolis terms at u-points are bounded by
-                                ! the four estimates of (f+rv)v from the four neighboring
-                                ! v-points, and similarly at v-points.  This option would
-                                ! have no effect on the SADOURNY Coriolis scheme if it
-                                ! were possible to use centered difference thickness fluxes.
+                                ! If true, the Coriolis terms at u-points are bounded by the four estimates of
+                                ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
+                                ! option would have no effect on the SADOURNY Coriolis scheme if it were
+                                ! possible to use centered difference thickness fluxes.
 KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
-                                ! KE_SCHEME selects the discretization for acceleration
-                                ! due to the kinetic energy gradient. Valid values are:
+                                ! KE_SCHEME selects the discretization for acceleration due to the kinetic
+                                ! energy gradient. Valid values are:
                                 !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
 PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
-                                ! PV_ADV_SCHEME selects the discretization for PV
-                                ! advection. Valid values are:
+                                ! PV_ADV_SCHEME selects the discretization for PV advection. Valid values are:
                                 !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_PressureForce ===
 ANALYTIC_FV_PGF = True          !   [Boolean] default = True
-                                ! If true the pressure gradient forces are calculated
-                                ! with a finite volume form that analytically integrates
-                                ! the equations of state in pressure to avoid any
-                                ! possibility of numerical thermobaric instability, as
-                                ! described in Adcroft et al., O. Mod. (2008).
+                                ! If true the pressure gradient forces are calculated with a finite volume form
+                                ! that analytically integrates the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as described in Adcroft et
+                                ! al., O. Mod. (2008).
 
 ! === module MOM_PressureForce_AFV ===
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
-                                ! If true, use mass weighting when interpolating T/S for
-                                ! integrals near the bathymetry in AFV pressure gradient
-                                ! calculations.
+                                ! If true, use mass weighting when interpolating T/S for integrals near the
+                                ! bathymetry in AFV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
-                                ! If True, use vertical reconstruction of T & S within
-                                ! the integrals of the FV pressure gradient calculation.
-                                ! If False, use the constant-by-layer algorithm.
+                                ! If True, use vertical reconstruction of T & S within the integrals of the FV
+                                ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
-                                ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation.
+                                ! Order of vertical reconstruction of T/S to use in the integrals within the FV
+                                ! pressure gradient calculation.
                                 !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
-                                ! If true, the reconstruction of T & S for pressure in
-                                ! boundary cells is extrapolated, rather than using PCM
-                                ! in these cells. If true, the same order polynomial is
-                                ! used as is used for the interior cells.
+                                ! If true, the reconstruction of T & S for pressure in boundary cells is
+                                ! extrapolated, rather than using PCM in these cells. If true, the same order
+                                ! polynomial is used as is used for the interior cells.
 
 ! === module MOM_hor_visc ===
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
-                                ! If true, use a biharmonic horizontal viscosity.
-                                ! BIHARMONIC may be used with LAPLACIAN.
+                                ! If true, use a biharmonic horizontal viscosity. BIHARMONIC may be used with
+                                ! LAPLACIAN.
 AH = 0.0                        !   [m4 s-1] default = 0.0
                                 ! The background biharmonic horizontal viscosity.
 AH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the biharmonic viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+                                ! The velocity scale which is multiplied by the cube of the grid spacing to
+                                ! calculate the biharmonic viscosity. The final viscosity is the largest of this
+                                ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 AH_TIME_SCALE = 0.0             !   [s] default = 0.0
-                                ! A time scale whose inverse is multiplied by the fourth
-                                ! power of the grid spacing to calculate biharmonic viscosity.
-                                ! The final viscosity is the largest of all viscosity
-                                ! formulations in use. 0.0 means that it's not used.
+                                ! A time scale whose inverse is multiplied by the fourth power of the grid
+                                ! spacing to calculate biharmonic viscosity. The final viscosity is the largest
+                                ! of all viscosity formulations in use. 0.0 means that it's not used.
 SMAGORINSKY_AH = False          !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
 LEITH_AH = False                !   [Boolean] default = False
-                                ! If true, use a biharmonic Leith nonlinear eddy
-                                ! viscosity.
+                                ! If true, use a biharmonic Leith nonlinear eddy viscosity.
 BOUND_AH = True                 !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable.
+                                ! If true, the biharmonic coefficient is locally limited to be stable.
 BETTER_BOUND_AH = True          !   [Boolean] default = True
-                                ! If true, the biharmonic coefficient is locally limited
-                                ! to be stable with a better bounding than just BOUND_AH.
+                                ! If true, the biharmonic coefficient is locally limited to be stable with a
+                                ! better bounding than just BOUND_AH.
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-                                ! If true, use Use the land mask for the computation of thicknesses
-                                ! at velocity locations. This eliminates the dependence on arbitrary
-                                ! values over land or outside of the domain. Default is False in order to
-                                ! maintain answers with legacy experiments but should be changed to True
-                                ! for new experiments.
+                                ! If true, use Use the land mask for the computation of thicknesses at velocity
+                                ! locations. This eliminates the dependence on arbitrary values over land or
+                                ! outside of the domain. Default is False in order to maintain answers with
+                                ! legacy experiments but should be changed to True for new experiments.
 HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
-                                ! The nondimensional coefficient of the ratio of the
-                                ! viscosity bounds to the theoretical maximum for
-                                ! stability without considering other terms.
+                                ! The nondimensional coefficient of the ratio of the viscosity bounds to the
+                                ! theoretical maximum for stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
-                                ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other
-                                ! terms and this background value.
+                                ! If true, read a file containing 2-d background harmonic viscosities. The final
+                                ! viscosity is the maximum of the other terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
-                                ! If true, the wind stress is distributed over the
-                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
-                                ! may be set to a very small value.
+                                ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
+                                ! (like in HYCOM), and KVML may be set to a very small value.
 HARMONIC_VISC = False           !   [Boolean] default = False
-                                ! If true, use the harmonic mean thicknesses for
-                                ! calculating the vertical viscosity.
+                                ! If true, use the harmonic mean thicknesses for calculating the vertical
+                                ! viscosity.
 HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
-                                ! A scale to determine when water is in the boundary
-                                ! layers based solely on harmonic mean thicknesses for
-                                ! the purpose of determining the extent to which the
-                                ! thicknesses used in the viscosities are upwinded.
+                                ! A scale to determine when water is in the boundary layers based solely on
+                                ! harmonic mean thicknesses for the purpose of determining the extent to which
+                                ! the thicknesses used in the viscosities are upwinded.
 HMIX_FIXED = 1.0                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 KVML = 1.0                      !   [m2 s-1] default = 1.0
-                                ! The kinematic viscosity in the mixed layer.  A typical
-                                ! value is ~1e-2 m2 s-1. KVML is not used if
-                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 KVBBL = 1.0                     !   [m2 s-1] default = 1.0
-                                ! The kinematic viscosity in the benthic boundary layer.
-                                ! A typical value is ~1e-2 m2 s-1. KVBBL is not used if
-                                ! BOTTOMDRAGLAW is true.  The default is set by KV.
+                                ! The kinematic viscosity in the benthic boundary layer. A typical value is
+                                ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
+                                ! by KV.
 MAXVEL = 3.0E+08                !   [m s-1] default = 3.0E+08
-                                ! The maximum velocity allowed before the velocity
-                                ! components are truncated.
+                                ! The maximum velocity allowed before the velocity components are truncated.
 CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
-                                ! If true, base truncations on the CFL number, and not an
-                                ! absolute speed.
+                                ! If true, base truncations on the CFL number, and not an absolute speed.
 CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
-                                ! The value of the CFL number that will cause velocity
-                                ! components to be truncated; instability can occur past 0.5.
+                                ! The value of the CFL number that will cause velocity components to be
+                                ! truncated; instability can occur past 0.5.
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
-                                ! The value of the CFL number that causes accelerations
-                                ! to be reported; the default is CFL_TRUNCATE.
+                                ! The value of the CFL number that causes accelerations to be reported; the
+                                ! default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL truncation value is ramped
-                                ! up at the beginning of the run.
+                                ! The time over which the CFL truncation value is ramped up at the beginning of
+                                ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
-                                ! The start value of the truncation CFL number used when
-                                ! ramping up CFL_TRUNC.
+                                ! The start value of the truncation CFL number used when ramping up CFL_TRUNC.
 STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
-                                ! Flag to use Stokes drift Mixing via the Lagrangian
-                                !  current (Eulerian plus Stokes drift).
-                                !  Still needs work and testing, so not recommended for use.
+                                ! Flag to use Stokes drift Mixing via the Lagrangian  current (Eulerian plus
+                                ! Stokes drift).  Still needs work and testing, so not recommended for use.
 VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
-                                ! A negligibly small velocity magnitude below which velocity
-                                ! components are set to 0.  A reasonable value might be
-                                ! 1e-30 m/s, which is less than an Angstrom divided by
-                                ! the age of the universe.
+                                ! A negligibly small velocity magnitude below which velocity components are set
+                                ! to 0.  A reasonable value might be 1e-30 m/s, which is less than an Angstrom
+                                ! divided by the age of the universe.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -753,43 +680,39 @@ KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
-                                ! The maximum value of the local diffusive CFL ratio that
-                                ! is permitted for the thickness diffusivity. 1.0 is the
-                                ! marginally unstable value in a pure layered model, but
-                                ! much smaller numbers (e.g. 0.1) seem to work better for
-                                ! ALE-based models.
+                                ! The maximum value of the local diffusive CFL ratio that is permitted for the
+                                ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
+                                ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
+                                ! models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
-                                ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizontally smooth jagged layers.
+                                ! If defined add 3-d structured enhanced interface height diffusivities to
+                                ! horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
-                                ! A slope beyond which the calculated isopycnal slope is
-                                ! not reliable and is scaled away.
+                                ! A slope beyond which the calculated isopycnal slope is not reliable and is
+                                ! scaled away.
 KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
-                                ! A diapycnal diffusivity that is used to interpolate
-                                ! more sensible values of T & S into thin layers.
+                                ! A diapycnal diffusivity that is used to interpolate more sensible values of T
+                                ! & S into thin layers.
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
-                                ! If true, use the streamfunction formulation of
-                                ! Ferrari et al., 2010, which effectively emphasizes
-                                ! graver vertical modes by smoothing in the vertical.
+                                ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
+                                ! effectively emphasizes graver vertical modes by smoothing in the vertical.
 
 ! === module MOM_mixed_layer_restrat ===
 MIXEDLAYER_RESTRAT = False      !   [Boolean] default = False
-                                ! If true, a density-gradient dependent re-stratifying
-                                ! flow is imposed in the mixed layer. Can be used in ALE mode
-                                ! without restriction but in layer mode can only be used if
-                                ! BULKMIXEDLAYER is true.
+                                ! If true, a density-gradient dependent re-stratifying flow is imposed in the
+                                ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
+                                ! only be used if BULKMIXEDLAYER is true.
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
-                                ! The lower fraction of water column over which N2 is limited as monotonic
-                                ! for the purposes of calculating the equivalent barotropic wave speed.
+                                ! The lower fraction of water column over which N2 is limited as monotonic for
+                                ! the purposes of calculating the equivalent barotropic wave speed.
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
-                                ! The depth below which N2 is limited as monotonic for the
-                                ! purposes of calculating the equivalent barotropic wave speed.
+                                ! The depth below which N2 is limited as monotonic for the purposes of
+                                ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
 Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
+                                ! The file that specifies the vertical grid for depth-space diagnostics, or
+                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -809,91 +732,82 @@ KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
-                                ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passivity is the ratio
-                                ! between along isopycnal mixing of tracers to thickness mixing.
-                                ! A non-zero value enables this parameterization.
+                                ! The coefficient that scales deformation radius over grid-spacing in passivity,
+                                ! where passivity is the ratio between along isopycnal mixing of tracers to
+                                ! thickness mixing. A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
-                                ! The minimum passivity which is the ratio between
-                                ! along isopycnal mixing of tracers to thickness mixing.
+                                ! The minimum passivity which is the ratio between along isopycnal mixing of
+                                ! tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
-                                ! If true, enable epipycnal mixing between the surface
-                                ! boundary layer and the interior.
+                                ! If true, enable epipycnal mixing between the surface boundary layer and the
+                                ! interior.
 CHECK_DIFFUSIVE_CFL = False     !   [Boolean] default = False
-                                ! If true, use enough iterations the diffusion to ensure
-                                ! that the diffusive equivalent of the CFL limit is not
-                                ! violated.  If false, always use the greater of 1 or
-                                ! MAX_TR_DIFFUSION_CFL iteration.
+                                ! If true, use enough iterations the diffusion to ensure that the diffusive
+                                ! equivalent of the CFL limit is not violated.  If false, always use the greater
+                                ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
-                                ! If positive, locally limit the along-isopycnal tracer
-                                ! diffusivity to keep the diffusive CFL locally at or
-                                ! below this value.  The number of diffusive iterations
-                                ! is often this value or the next greater integer.
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = False   !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
-                                ! If an obsolete diagnostic variable appears in the diag_table
-                                ! then cause a FATAL error rather than issue a WARNING.
+                                ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
+                                ! error rather than issue a WARNING.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
-                                ! If true, calculate the available potential energy of
-                                ! the interfaces.  Setting this to false reduces the
-                                ! memory footprint of high-PE-count models dramatically.
+                                ! If true, calculate the available potential energy of the interfaces.  Setting
+                                ! this to false reduces the memory footprint of high-PE-count models
+                                ! dramatically.
 WRITE_STOCKS = True             !   [Boolean] default = True
-                                ! If true, write the integrated tracer amounts to stdout
-                                ! when the energy files are written.
+                                ! If true, write the integrated tracer amounts to stdout when the energy files
+                                ! are written.
 MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
-                                ! The run will be stopped, and the day set to a very
-                                ! large value if the velocity is truncated more than
-                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! The run will be stopped, and the day set to a very large value if the velocity
+                                ! is truncated more than MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
                                 ! to stop if there is any truncation of velocities.
 MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
-                                ! The maximum permitted average energy per unit mass; the
-                                ! model will be stopped if there is more energy than
-                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+                                ! The maximum permitted average energy per unit mass; the model will be stopped
+                                ! if there is more energy than this.  If zero or negative, this is set to
+                                ! 10*MAXVEL^2.
 ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
-                                ! The file to use to write the energies and globally
-                                ! summed diagnostics.
+                                ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
-                                ! Read the depth list from a file if it exists or
-                                ! create that file otherwise.
+                                ! Read the depth list from a file if it exists or create that file otherwise.
 DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
-                                ! The minimum increment between the depths of the
-                                ! entries in the depth-list file.
+                                ! The minimum increment between the depths of the entries in the depth-list
+                                ! file.
 ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
-                                ! The interval in units of TIMEUNIT between saves of the
-                                ! energies of the run and other globally summed diagnostics.
+                                ! The interval in units of TIMEUNIT between saves of the energies of the run and
+                                ! other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
-                                ! The starting interval in units of TIMEUNIT for the first call
-                                ! to save the energies of the run and other globally summed diagnostics.
-                                ! The interval increases by a factor of 2. after each call to write_energy.
+                                ! The starting interval in units of TIMEUNIT for the first call to save the
+                                ! energies of the run and other globally summed diagnostics. The interval
+                                ! increases by a factor of 2. after each call to write_energy.
 
 ! === module MOM_surface_forcing ===
 VARIABLE_WINDS = True           !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
-                                ! If true, the buoyancy forcing varies in time after the
-                                ! initialization of the model.
+                                ! If true, the buoyancy forcing varies in time after the initialization of the
+                                ! model.
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
-                                ! If true, the buoyancy fluxes drive the model back
-                                ! toward some specified surface state with a rate
-                                ! given by FLUXCONST.
+                                ! If true, the buoyancy fluxes drive the model back toward some specified
+                                ! surface state with a rate given by FLUXCONST.
 LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
                                 ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
@@ -901,8 +815,7 @@ LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
 GUST_CONST = 0.02               !   [Pa] default = 0.02
                                 ! The background gustiness in the winds.
 READ_GUST_2D = False            !   [Boolean] default = False
-                                ! If true, use a 2-dimensional gustiness supplied from
-                                ! an input file
+                                ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
 ICE_SHELF = False               !   [Boolean] default = False
@@ -910,48 +823,41 @@ ICE_SHELF = False               !   [Boolean] default = False
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
-                                ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
+                                ! The depth (normalized by BLD) to average Stokes drift over in Langmuir number
+                                ! calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 8.64E+04           !   [s] default = 8.64E+04
-                                ! The time step for changing forcing, coupling with other
-                                ! components, or potentially writing certain diagnostics.
-                                ! The default value is given by DT.
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 SINGLE_STEPPING_CALL = True     !   [Boolean] default = True
-                                ! If true, advance the state of MOM with a single step
-                                ! including both dynamics and thermodynamics.  If false
-                                ! the two phases are advanced with separate calls.
+                                ! If true, advance the state of MOM with a single step including both dynamics
+                                ! and thermodynamics.  If false the two phases are advanced with separate calls.
 RESTART_CONTROL = 1             ! default = 1
-                                ! An integer whose bits encode which restart files are
-                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
-                                ! (bit 0) for a non-time-stamped file. A non-time-stamped
-                                ! restart file is saved at the end of the run segment
-                                ! for any non-negative value.
+                                ! An integer whose bits encode which restart files are written. Add 2 (bit 1)
+                                ! for a time-stamped file, and odd (bit 0) for a non-time-stamped file. A
+                                ! non-time-stamped restart file is saved at the end of the run segment for any
+                                ! non-negative value.
 RESTINT = 0.0                   !   [days] default = 0.0
-                                ! The interval between saves of the restart file in units
-                                ! of TIMEUNIT.  Use 0 (the default) to not save
-                                ! incremental restart files at all.
+                                ! The interval between saves of the restart file in units of TIMEUNIT.  Use 0
+                                ! (the default) to not save incremental restart files at all.
 WRITE_CPU_STEPS = 1000          ! default = 1000
-                                ! The number of coupled timesteps between writing the cpu
-                                ! time. If this is not positive, do not check cpu time, and
-                                ! the segment run-length can not be set via an elapsed CPU time.
+                                ! The number of coupled timesteps between writing the cpu time. If this is not
+                                ! positive, do not check cpu time, and the segment run-length can not be set via
+                                ! an elapsed CPU time.
 
 ! === module MOM_write_cputime ===
 MAXCPU = -1.0                   !   [wall-clock seconds] default = -1.0
-                                ! The maximum amount of cpu time per processor for which
-                                ! MOM should run before saving a restart file and
-                                ! quitting with a return value that indicates that a
-                                ! further run is required to complete the simulation.
-                                ! If automatic restarts are not desired, use a negative
-                                ! value for MAXCPU.  MAXCPU has units of wall-clock
-                                ! seconds, so the actual CPU time used is larger by a
-                                ! factor of the number of processors used.
+                                ! The maximum amount of cpu time per processor for which MOM should run before
+                                ! saving a restart file and quitting with a return value that indicates that a
+                                ! further run is required to complete the simulation. If automatic restarts are
+                                ! not desired, use a negative value for MAXCPU.  MAXCPU has units of wall-clock
+                                ! seconds, so the actual CPU time used is larger by a factor of the number of
+                                ! processors used.
 CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
                                 ! The file into which CPU time is written.
 
@@ -959,12 +865,10 @@ CPU_TIME_FILE = "CPU_stats"     ! default = "CPU_stats"
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
                                 ! If true, all log messages are also sent to stdout.
 DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
-                                ! The basename for files where run-time parameters, their
-                                ! settings, units and defaults are documented. Blank will
-                                ! disable all parameter documentation.
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
 COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
-                                ! If true, all run-time parameters are
-                                ! documented in MOM_parameter_doc.all .
+                                ! If true, all run-time parameters are documented in MOM_parameter_doc.all .
 MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
-                                ! If true, non-default run-time parameters are
-                                ! documented in MOM_parameter_doc.short .
+                                ! If true, non-default run-time parameters are documented in
+                                ! MOM_parameter_doc.short .

--- a/ocean_only/unit_tests/MOM_parameter_doc.debugging
+++ b/ocean_only/unit_tests/MOM_parameter_doc.debugging
@@ -7,41 +7,35 @@ VERBOSITY = 2                   ! default = 2
 DO_UNIT_TESTS = True            !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
 Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! depths and heights.  Valid values range from -300 to 300.
 L_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! lateral distances.  Valid values range from -300 to 300.
 T_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of time.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
-                                ! If true, calculate all diagnostics that are useful for
-                                ! debugging truncations.
+                                ! If true, calculate all diagnostics that are useful for debugging truncations.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
-                                ! If true, checksums are performed on arrays in the
-                                ! various vec_chksum routines.
+                                ! If true, checksums are performed on arrays in the various vec_chksum routines.
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
-                                ! If true, debug redundant data points during calls to
-                                ! the various vec_chksum routines.
+                                ! If true, debug redundant data points during calls to the various vec_chksum
+                                ! routines.
 H_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of thickness.  Valid values range from -300 to 300.
+                                ! An integer power of 2 that is used to rescale the model's intenal units of
+                                ! thickness.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to zonal velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to zonal
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 V_TRUNC_FILE = ""               ! default = ""
-                                ! The absolute path to a file into which the accelerations
-                                ! leading to meridional velocity truncations are written.
-                                ! Undefine this for efficiency if this diagnostic is not
-                                ! needed.
+                                ! The absolute path to a file into which the accelerations leading to meridional
+                                ! velocity truncations are written. Undefine this for efficiency if this
+                                ! diagnostic is not needed.
 REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
-                                ! If true, report any parameter lines that are not used
-                                ! in the run.
+                                ! If true, report any parameter lines that are not used in the run.
 FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
-                                ! If true, kill the run if there are any unused
-                                ! parameters.
+                                ! If true, kill the run if there are any unused parameters.

--- a/ocean_only/unit_tests/MOM_parameter_doc.layout
+++ b/ocean_only/unit_tests/MOM_parameter_doc.layout
@@ -1,63 +1,56 @@
 ! This file was written by the model and records the layout parameters used at run-time.
 GLOBAL_INDEXING = False         !   [Boolean] default = False
-                                ! If true, use a global lateral indexing convention, so
-                                ! that corresponding points on different processors have
-                                ! the same index. This does not work with static memory.
+                                ! If true, use a global lateral indexing convention, so that corresponding
+                                ! points on different processors have the same index. This does not work with
+                                ! static memory.
 !SYMMETRIC_MEMORY_ = True       !   [Boolean]
-                                ! If defined, the velocity point data domain includes
-                                ! every face of the thickness points. In other words,
-                                ! some arrays are larger than others, depending on where
-                                ! they are on the staggered grid.  Also, the starting
-                                ! index of the velocity-point arrays is usually 0, not 1.
-                                ! This can only be set at compile time.
+                                ! If defined, the velocity point data domain includes every face of the
+                                ! thickness points. In other words, some arrays are larger than others,
+                                ! depending on where they are on the staggered grid.  Also, the starting index
+                                ! of the velocity-point arrays is usually 0, not 1. This can only be set at
+                                ! compile time.
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the
-                                ! The width of the halos that are updated with each call.
+                                ! If true, optional arguments may be used to specify the the width of the halos
+                                ! that are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
-                                ! If STATIC_MEMORY_ is defined, the principle variables
-                                ! will have sizes that are statically determined at
-                                ! compile time.  Otherwise the sizes are not determined
-                                ! until run time. The STATIC option is substantially
-                                ! faster, but does not allow the PE count to be changed
-                                ! at run time.  This can only be set at compile time.
+                                ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
+                                ! statically determined at compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially faster, but does not allow
+                                ! the PE count to be changed at run time.  This can only be set at compile time.
 NIHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the x-direction.  With
+                                ! STATIC_MEMORY_ this is set as NIHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NIHALO_ in MOM_memory.h (if defined) or 2.
 NJHALO = 4                      ! default = 4
-                                ! The number of halo points on each side in the
-                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
-                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
-                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+                                ! The number of halo points on each side in the y-direction.  With
+                                ! STATIC_MEMORY_ this is set as NJHALO_ in MOM_memory.h at compile time; without
+                                ! STATIC_MEMORY_ the default is NJHALO_ in MOM_memory.h (if defined) or 2.
 MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list.
-                                ! This feature masks out processors that contain only land points.
-                                ! The first line of mask_table is the number of regions to be masked out.
-                                ! The second line is the layout of the model and must be
-                                ! consistent with the actual model layout.
-                                ! The following (n_mask) lines give the logical positions
-                                ! of the processors that are masked out. The mask_table
-                                ! can be created by tools like check_mask. The
-                                ! following example of mask_table masks out 2 processors,
-                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
+                                ! processors that contain only land points. The first line of mask_table is the
+                                ! number of regions to be masked out. The second line is the layout of the model
+                                ! and must be consistent with the actual model layout. The following (n_mask)
+                                ! lines give the logical positions of the processors that are masked out. The
+                                ! mask_table can be created by tools like check_mask. The following example of
+                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
+                                ! layout:
                                 !  2
                                 !  4,6
                                 !  1,2
                                 !  3,6
 NIPROC = 1                      !
-                                ! The number of processors in the x-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 NJPROC = 1                      !
-                                ! The number of processors in the y-direction. With
-                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+                                ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
+                                ! in MOM_memory.h at compile time.
 LAYOUT = 1, 1                   !
                                 ! The processor layout that was actually used.
 IO_LAYOUT = 1, 1                ! default = 1
-                                ! The processor layout to be used, or 0,0 to automatically
-                                ! set the io_layout to be the same as the layout.
+                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
+                                ! be the same as the layout.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
 NJBLOCK = 1                     ! default = 1

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -7,28 +7,23 @@
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
-                                ! If true, Temperature and salinity are used as state
-                                ! variables.
+                                ! If true, Temperature and salinity are used as state variables.
 ADIABATIC = True                !   [Boolean] default = False
-                                ! There are no diapycnal mass fluxes if ADIABATIC is
-                                ! true. This assumes that KD = KDML = 0.0 and that
-                                ! there is no buoyancy forcing, but makes the model
-                                ! faster by eliminating subroutine calls.
+                                ! There are no diapycnal mass fluxes if ADIABATIC is true. This assumes that KD
+                                ! = KDML = 0.0 and that there is no buoyancy forcing, but makes the model faster
+                                ! by eliminating subroutine calls.
 DT = 8.64E+04                   !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that
-                                ! is actually used will be an integer fraction of the
-                                ! forcing time-step (DT_FORCING in ocean-only mode or the
-                                ! coupling timestep in coupled mode.)
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
 
 ! === module MOM_domains ===
 NIGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! x-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the x-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NJGLOBAL = 4                    !
-                                ! The total number of thickness grid points in the
-                                ! y-direction in the physical domain. With STATIC_MEMORY_
-                                ! this is set in MOM_memory.h at compile time.
+                                ! The total number of thickness grid points in the y-direction in the physical
+                                ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -42,16 +37,16 @@ NK = 1                          !   [nondim]
 
 ! === module MOM_grid_init ===
 GRID_CONFIG = "cartesian"       !
-                                ! A character string that determines the method for
-                                ! defining the horizontal grid.  Current options are:
+                                ! A character string that determines the method for defining the horizontal
+                                ! grid.  Current options are:
                                 !     mosaic - read the grid from a mosaic (supergrid)
                                 !              file set by GRID_FILE.
                                 !     cartesian - use a (flat) Cartesian grid.
                                 !     spherical - use a simple spherical grid.
                                 !     mercator - use a Mercator spherical grid.
 SOUTHLAT = 0.0                  !   [degrees]
-                                ! The southern latitude of the domain or the equivalent
-                                ! starting value for the y-axis.
+                                ! The southern latitude of the domain or the equivalent starting value for the
+                                ! y-axis.
 LENLAT = 1.0                    !   [degrees]
                                 ! The latitudinal or y-direction length of the domain.
 LENLON = 1.0                    !   [degrees]
@@ -86,8 +81,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition
-! to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 
 ! === module MOM_tracer_registry ===
 
@@ -120,8 +115,8 @@ COORD_CONFIG = "none"           !
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "uniform"    !
-                                ! A string that determines how the initial layer
-                                ! thicknesses are specified for a new run:
+                                ! A string that determines how the initial layer thicknesses are specified for a
+                                ! new run:
                                 !     file - read interface heights from the file specified
                                 !     thickness_file - read thicknesses from the file specified
                                 !       by (THICKNESS_FILE).
@@ -155,32 +150,27 @@ THICKNESS_CONFIG = "uniform"    !
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = False           !   [Boolean] default = True
-                                ! If true, the bottom stress is calculated with a drag
-                                ! law of the form c_drag*|u|*u. The velocity magnitude
-                                ! may be an assumed value or it may be based on the
-                                ! actual velocity in the bottommost HBBL, depending on
-                                ! LINEAR_DRAG.
+                                ! If true, the bottom stress is calculated with a drag law of the form
+                                ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
+                                ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
 HBBL = 1.0                      !   [m]
-                                ! The thickness of a bottom boundary layer with a
-                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-                                ! the thickness over which near-bottom velocities are
-                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
-                                ! but LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
+                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+                                ! LINEAR_DRAG is not.
 KV = 1.0                        !   [m2 s-1]
-                                ! The background kinematic viscosity in the interior.
-                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+                                ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
+                                ! m2 s-1, may be used.
 
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
 SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
-                                ! If true, CONTINUITY_PPM uses a simple 2nd order
-                                ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation properties. While
-                                ! it formally reduces the accuracy of the continuity
-                                ! solver itself in the strongly advective limit, it does
-                                ! not reduce the overall order of accuracy of the dynamic
-                                ! core.
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order (arithmetic mean)
+                                ! interpolation of the edge values. This may give better PV conservation
+                                ! properties. While it formally reduces the accuracy of the continuity solver
+                                ! itself in the strongly advective limit, it does not reduce the overall order
+                                ! of accuracy of the dynamic core.
 
 ! === module MOM_CoriolisAdv ===
 
@@ -192,9 +182,8 @@ SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
 
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 1.0                !   [m]
-                                ! The prescribed depth over which the near-surface
-                                ! viscosity and diffusivity are elevated when the bulk
-                                ! mixed layer is not used.
+                                ! The prescribed depth over which the near-surface viscosity and diffusivity are
+                                ! elevated when the bulk mixed layer is not used.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -216,21 +205,18 @@ HMIX_FIXED = 1.0                !   [m]
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "zero"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified. Valid
+                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 WIND_CONFIG = "zero"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified. Valid
+                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 
 ! === module MOM_restart ===
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 1.0                    !   [days]
-                                ! The final time of the whole simulation, in units of
-                                ! TIMEUNIT seconds.  This also sets the potential end
-                                ! time of the present run segment if the end time is
+                                ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
+                                ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.
 
 ! === module MOM_write_cputime ===


### PR DESCRIPTION
  Removed hard newlines from numerous get_param and log_param descriptions
throughout the MOM6 codebase, relying instead on the new automatic newline
capability in writeMessageAndDesc.  In the case of formatted lists of options,
the hard newlines were retained. This cleans up the code and gives more standard
messages and smaller parameter_doc files, but it changes the comments in every
MOM_parameter_doc and SIS_parameter_doc file. All answers are bitwise identical.
This also corrects some updates to MOM_parameter_doc.all files that were omitted
in a recent hand-merge.  The MOM6 commit in the corresponding MOM6 PR (https://github.com/NOAA-GFDL/MOM6/pull/927) is:

- NOAA-GFDL/MOM6@a236032 +Removed hard newlines in get_param calls